### PR TITLE
File expand on relative paths with pattern

### DIFF
--- a/neuromation/cli/storage.py
+++ b/neuromation/cli/storage.py
@@ -5,6 +5,7 @@ import os
 import secrets
 import shlex
 import sys
+from pathlib import Path
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 import aiodocker
@@ -844,7 +845,7 @@ async def _expand(
                     uris.append(file)
             elif allow_file and uri.scheme == "file":
                 for p in globmodule.iglob(uri_path, recursive=True):
-                    uris.append(uri.with_path(p))
+                    uris.append(URL(Path(p).as_uri()))
             else:
                 uris.append(uri)
         else:

--- a/neuromation/cli/storage.py
+++ b/neuromation/cli/storage.py
@@ -842,7 +842,7 @@ async def _expand(
             if uri.scheme == "storage":
                 async for file in root.client.storage.glob(uri):
                     uris.append(file)
-            elif allow_file and path.startswith("file:"):
+            elif allow_file and uri.scheme == "file":
                 for p in globmodule.iglob(uri_path, recursive=True):
                     uris.append(uri.with_path(p))
             else:

--- a/tests/cli/test_storage.py
+++ b/tests/cli/test_storage.py
@@ -6,7 +6,7 @@ import toml
 from yarl import URL
 
 from neuromation.api import Client
-from neuromation.cli.storage import _expand, calc_filters, parse_file_resource
+from neuromation.cli.storage import _expand, calc_filters
 
 
 _MakeClient = Callable[..., Client]
@@ -54,15 +54,6 @@ async def test_storage__expand_file(
         root.verbosity = 0
         root.client = client
 
-        print("TEST it")
-        print(tmp_path)
-        print(type(tmp_path))
-        print(tmp_path.as_uri())
-        print(Path(str(tmp_path)).as_uri())
-        print(tmp_path.as_posix())
-        print(Path(str(tmp_path)).as_posix())
-        print(parse_file_resource(str(tmp_path), root=root))
-
         # Create file structure
         for path in [
             tmp_path / "file1.txt",
@@ -73,7 +64,7 @@ async def test_storage__expand_file(
             path.parent.mkdir(exist_ok=True)
             with path.open("w"):
                 pass
-        base_url = URL("file://" + tmp_path.as_posix())
+        base_url = URL(tmp_path.as_uri())
 
         assert await _expand(paths=[], root=root, glob=True, allow_file=True) == []
         # User expand cases

--- a/tests/cli/test_storage.py
+++ b/tests/cli/test_storage.py
@@ -64,7 +64,7 @@ async def test_storage__expand_file(
             path.parent.mkdir(exist_ok=True)
             with path.open("w"):
                 pass
-        base_url = URL("file://" + str(tmp_path))
+        base_url = URL(tmp_path.as_uri())
 
         assert await _expand(paths=[], root=root, glob=True, allow_file=True) == []
         # User expand cases
@@ -111,7 +111,7 @@ async def test_storage__expand_file(
 
         # File scheme cases
         uris = await _expand(
-            paths=[f"file://{str(tmp_path)}/**/*.json"],
+            paths=[str(URL(tmp_path.as_uri()) / "**" / "*.json")],
             root=root,
             glob=True,
             allow_file=True,

--- a/tests/cli/test_storage.py
+++ b/tests/cli/test_storage.py
@@ -6,7 +6,7 @@ import toml
 from yarl import URL
 
 from neuromation.api import Client
-from neuromation.cli.storage import _expand, calc_filters
+from neuromation.cli.storage import _expand, calc_filters, parse_file_resource
 
 
 _MakeClient = Callable[..., Client]
@@ -53,6 +53,15 @@ async def test_storage__expand_file(
         root = mock.Mock()
         root.verbosity = 0
         root.client = client
+
+        print("TEST it")
+        print(tmp_path)
+        print(type(tmp_path))
+        print(tmp_path.as_uri())
+        print(Path(str(tmp_path)).as_uri())
+        print(tmp_path.as_posix())
+        print(Path(str(tmp_path)).as_posix())
+        print(parse_file_resource(str(tmp_path), root=root))
 
         # Create file structure
         for path in [

--- a/tests/cli/test_storage.py
+++ b/tests/cli/test_storage.py
@@ -64,7 +64,7 @@ async def test_storage__expand_file(
             path.parent.mkdir(exist_ok=True)
             with path.open("w"):
                 pass
-        base_url = URL(tmp_path.as_uri())
+        base_url = URL("file://" + tmp_path.as_posix())
 
         assert await _expand(paths=[], root=root, glob=True, allow_file=True) == []
         # User expand cases
@@ -111,7 +111,7 @@ async def test_storage__expand_file(
 
         # File scheme cases
         uris = await _expand(
-            paths=[str(URL(tmp_path.as_uri()) / "**" / "*.json")],
+            paths=[str(base_url / "**" / "*.json")],
             root=root,
             glob=True,
             allow_file=True,

--- a/tests/cli/test_storage.py
+++ b/tests/cli/test_storage.py
@@ -86,7 +86,7 @@ async def test_storage__expand_file(
         ]
         uris = await _expand(paths=["~/**"], root=root, glob=True, allow_file=True)
         assert sorted(uris) == [
-            base_url / "",
+            base_url,
             base_url / "chdir",
             base_url / "file1.txt",
             base_url / "file2.json",
@@ -98,7 +98,7 @@ async def test_storage__expand_file(
         # Relative expand cases
         uris = await _expand(paths=["./**"], root=root, glob=True, allow_file=True)
         assert sorted(uris) == [
-            base_url / "chdir" / "",
+            base_url / "chdir",
         ]
         uris = await _expand(paths=["../*"], root=root, glob=True, allow_file=True)
         assert sorted(uris) == [
@@ -109,7 +109,7 @@ async def test_storage__expand_file(
         ]
         uris = await _expand(paths=["../**"], root=root, glob=True, allow_file=True)
         assert sorted(uris) == [
-            base_url / "chdir" / ".." / "",
+            base_url / "chdir" / "..",
             base_url / "chdir" / ".." / "chdir",
             base_url / "chdir" / ".." / "file1.txt",
             base_url / "chdir" / ".." / "file2.json",


### PR DESCRIPTION
The problem:
```
⇒  neuro cp "~/Downloads/DEMO/*" storage:
Copy file:///Users/taras/Downloads/DEMO/* => storage://tvoinarovskyi/*
ERROR: cannot copy file:///Users/taras/Downloads/DEMO/* to storage://tvoinarovskyi/*: [Errno 2] No such file: '/Users/taras/Downloads/DEMO/*'
```

Added tests for _expand on file schemas too