### PR TITLE
Use SI suffixes instead of GNU suffixes for memory sizes

### DIFF
--- a/CHANGELOG.D/1731.feature
+++ b/CHANGELOG.D/1731.feature
@@ -1,2 +1,0 @@
-Memory amount parsing now supports of both `b` and `B` suffixes for specifying decimal
-quantities. Improved `neuro disk create` docs.

--- a/CHANGELOG.D/1733.feature
+++ b/CHANGELOG.D/1733.feature
@@ -1,0 +1,1 @@
+Switched to SI scheme for memory sizes. Improved `neuro disk create` docs.

--- a/CLI.md
+++ b/CLI.md
@@ -1937,7 +1937,7 @@ Name | Description|
 
 ### neuro disk create
 
-Create a disk with at least storage amount STORAGE.<br/><br/>To specify the amount, you can use the following suffixes: "kKMGTPEZY" To<br/>use decimal quantities, append "b" or "B". For example: - 1K or 1k is 1024<br/>bytes - 1Kb or 1KB is 1000 bytes - 20G is 20 * 2 ^ 30 bytes - 20Gb or 20GB<br/>is 20.000.000.000 bytes<br/><br/>Note that server can have big granularity \(for example, 1G) so it will<br/>possibly round-up the amount you requested.<br/>
+Create a disk with at least storage amount STORAGE.<br/><br/>To specify the amount, you can use the following SI suffixes: "kKMGTPE" To<br/>use decimal quantities, append "i" or "iB". For example: - 1k or 1K is 1000<br/>bytes - 1Ki or 1KiB is 1024 bytes - 20Gi or 20GiB is 20 * 2 ^ 30 bytes - 20G<br/>is 20.000.000.000 bytes<br/><br/>Note that server can have big granularity \(for example, 1Gi) so it will<br/>possibly round-up the amount you requested.<br/>
 
 **Usage:**
 
@@ -1949,8 +1949,8 @@ neuro disk create [OPTIONS] STORAGE
 
 ```bash
 
-neuro disk create 10G
-neuro disk create 500M
+neuro disk create 10Gi
+neuro disk create 500Mi
 
 ```
 

--- a/neuromation/cli/disks.py
+++ b/neuromation/cli/disks.py
@@ -41,20 +41,20 @@ async def create(root: Root, storage: str) -> None:
     """
     Create a disk with at least storage amount STORAGE.
 
-    To specify the amount, you can use the following suffixes: "kKMGTPEZY"
-    To use decimal quantities, append "b" or "B". For example:
-    - 1K or 1k is 1024 bytes
-    - 1Kb or 1KB is 1000 bytes
-    - 20G is 20 * 2 ^ 30 bytes
-    - 20Gb or 20GB is 20.000.000.000 bytes
+    To specify the amount, you can use the following SI suffixes: "kKMGTPE"
+    To use decimal quantities, append "i" or "iB". For example:
+    - 1k or 1K is 1000 bytes
+    - 1Ki or 1KiB is 1024 bytes
+    - 20Gi or 20GiB is 20 * 2 ^ 30 bytes
+    - 20G is 20.000.000.000 bytes
 
-    Note that server can have big granularity (for example, 1G)
+    Note that server can have big granularity (for example, 1Gi)
     so it will possibly round-up the amount you requested.
 
     Examples:
 
-      neuro disk create 10G
-      neuro disk create 500M
+      neuro disk create 10Gi
+      neuro disk create 500Mi
     """
     disk = await root.client.disks.create(parse_memory(storage))
     disk_fmtr = DiskFormatter(str)

--- a/neuromation/cli/formatters/blob_storage.py
+++ b/neuromation/cli/formatters/blob_storage.py
@@ -57,7 +57,7 @@ class LongBlobFormatter(BaseBlobFormatter):
     def to_columns_blob(self, file: BlobListing) -> Sequence[str]:
         date = time.strftime(TIME_FORMAT, time.localtime(file.modification_time))
         if self.human_readable:
-            size = format_size(file.size).rstrip("B")
+            size = format_size(file.size)
         else:
             size = str(file.size)
         name = self.painter.paint(str(file.uri), get_file_type(file))

--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -475,7 +475,7 @@ class LongFilesFormatter(BaseFilesFormatter):
         date = time.strftime(TIME_FORMAT, time.localtime(file.modification_time))
 
         if self.human_readable:
-            size = format_size(file.size).rstrip("B")
+            size = format_size(file.size)
         else:
             size = str(file.size)
 

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -582,7 +582,7 @@ else:
 
 
 def format_size(value: float) -> str:
-    return humanize.naturalsize(value, gnu=True)
+    return humanize.naturalsize(value, binary=True)
 
 
 def pager_maybe(

--- a/tests/cli/formatters/test_admin_formatters.py
+++ b/tests/cli/formatters/test_admin_formatters.py
@@ -135,9 +135,9 @@ class TestClustersFormatter:
             \x1b[1mdefault:\x1b[0m
               \x1b[1mStatus: \x1b[0mDeployed
               \x1b[1mNode pools:\x1b[0m
-                Machine       CPU  Memory                   GPU  Size
-                n1-highmem-8  7.0   45.0G                           2
-                n1-highmem-8  7.0   45.0G  1 x nvidia-tesla-k80     2"""  # noqa: E501, ignore line length
+                Machine       CPU    Memory                   GPU  Size
+                n1-highmem-8  7.0  45.0 GiB                           2
+                n1-highmem-8  7.0  45.0 GiB  1 x nvidia-tesla-k80     2"""  # noqa: E501, ignore line length
         )
         assert "\n".join(formatter(clusters)) == expected_out
 
@@ -170,8 +170,8 @@ class TestClustersFormatter:
               \x1b[1mCloud: \x1b[0mgcp
               \x1b[1mRegion: \x1b[0mus-central1
               \x1b[1mNode pools:\x1b[0m
-                Machine       CPU  Memory  Preemptible  GPU  TPU  Min  Max  Idle
-                n1-highmem-8  7.0   45.0G       √             √     1    2     1
-                n1-highmem-8  7.0   45.0G       ×             ×     1    2     0"""
+                Machine       CPU    Memory  Preemptible  GPU  TPU  Min  Max  Idle
+                n1-highmem-8  7.0  45.0 GiB       √             √     1    2     1
+                n1-highmem-8  7.0  45.0 GiB       ×             ×     1    2     0"""
         )
         assert "\n".join(formatter(clusters)) == expected_out

--- a/tests/cli/formatters/test_blob_formatters.py
+++ b/tests/cli/formatters/test_blob_formatters.py
@@ -104,12 +104,12 @@ class TestBlobFormatter:
 
         formatter = LongBlobFormatter(human_readable=True, color=False)
         assert list(formatter(self.list_results)) == [
-            "    1.0 Ki 2018-01-01 14:00:00 blob:neuro-public-bucket/file1024.txt",
-            " 1000.0 Ki 2018-01-01 00:00:00 blob:neuro-public-bucket/file_bigger.txt",
-            " 240 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/info.txt",
-            "   0 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/",
-            "                               blob:neuro-public-bucket/folder1/",
-            "                               blob:neuro-shared-bucket/folder2/",
+            "    1.0 KiB 2018-01-01 14:00:00 blob:neuro-public-bucket/file1024.txt",
+            " 1000.0 KiB 2018-01-01 00:00:00 blob:neuro-public-bucket/file_bigger.txt",
+            "  240 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/info.txt",
+            "    0 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/",
+            "                                blob:neuro-public-bucket/folder1/",
+            "                                blob:neuro-shared-bucket/folder2/",
         ]
 
         assert list(formatter(self.buckets)) == [

--- a/tests/cli/formatters/test_blob_formatters.py
+++ b/tests/cli/formatters/test_blob_formatters.py
@@ -104,12 +104,12 @@ class TestBlobFormatter:
 
         formatter = LongBlobFormatter(human_readable=True, color=False)
         assert list(formatter(self.list_results)) == [
-            "    1.0K 2018-01-01 14:00:00 blob:neuro-public-bucket/file1024.txt",
-            " 1000.0K 2018-01-01 00:00:00 blob:neuro-public-bucket/file_bigger.txt",
-            "     240 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/info.txt",
-            "       0 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/",
-            "                             blob:neuro-public-bucket/folder1/",
-            "                             blob:neuro-shared-bucket/folder2/",
+            "    1.0 Ki 2018-01-01 14:00:00 blob:neuro-public-bucket/file1024.txt",
+            " 1000.0 Ki 2018-01-01 00:00:00 blob:neuro-public-bucket/file_bigger.txt",
+            " 240 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/info.txt",
+            "   0 Bytes 2018-01-02 00:00:00 blob:neuro-shared-bucket/folder2/",
+            "                               blob:neuro-public-bucket/folder1/",
+            "                               blob:neuro-shared-bucket/folder2/",
         ]
 
         assert list(formatter(self.buckets)) == [

--- a/tests/cli/formatters/test_config_formatters.py
+++ b/tests/cli/formatters/test_config_formatters.py
@@ -32,11 +32,11 @@ class TestConfigFormatter:
               API URL: https://dev.neu.ro/api/v1
               Docker Registry URL: https://registry-dev.neu.ro
               Resource Presets:
-                Name       #CPU  Memory  Preemptible  GPU
-                gpu-small     7   30.0G       ×       1 x nvidia-tesla-k80
-                gpu-large     7   60.0G       ×       1 x nvidia-tesla-v100
-                cpu-small     7    2.0G       ×
-                cpu-large     7   14.0G       ×"""
+                Name       #CPU    Memory  Preemptible  GPU
+                gpu-small     7  30.0 GiB       ×       1 x nvidia-tesla-k80
+                gpu-large     7  60.0 GiB       ×       1 x nvidia-tesla-v100
+                cpu-small     7   2.0 GiB       ×
+                cpu-large     7  14.0 GiB       ×"""
         )
 
     async def test_output_for_tpu_presets(
@@ -77,14 +77,14 @@ class TestConfigFormatter:
               API URL: https://dev.neu.ro/api/v1
               Docker Registry URL: https://registry-dev.neu.ro
               Resource Presets:
-                Name         #CPU  Memory  Preemptible  GPU                    TPU
-                gpu-small       7   30.0G       ×       1 x nvidia-tesla-k80
-                gpu-large       7   60.0G       ×       1 x nvidia-tesla-v100
-                cpu-small       7    2.0G       ×
-                cpu-large       7   14.0G       ×
-                cpu-large-p     7   14.0G       √
-                tpu-small       2    2.0G       ×                              v3-8/1.14
-                hybrid          4   30.0G       ×       2 x nvidia-tesla-v100  v3-64/1.14"""  # noqa: E501, ignore line length
+                Name         #CPU    Memory  Preemptible  GPU                    TPU
+                gpu-small       7  30.0 GiB       ×       1 x nvidia-tesla-k80
+                gpu-large       7  60.0 GiB       ×       1 x nvidia-tesla-v100
+                cpu-small       7   2.0 GiB       ×
+                cpu-large       7  14.0 GiB       ×
+                cpu-large-p     7  14.0 GiB       √
+                tpu-small       2   2.0 GiB       ×                              v3-8/1.14
+                hybrid          4  30.0 GiB       ×       2 x nvidia-tesla-v100  v3-64/1.14"""  # noqa: E501, ignore line length
         )
 
     async def test_output_with_jobs_available(self, root: Root) -> None:
@@ -103,11 +103,11 @@ class TestConfigFormatter:
               API URL: https://dev.neu.ro/api/v1
               Docker Registry URL: https://registry-dev.neu.ro
               Resource Presets:
-                Name       #CPU  Memory  Preemptible  GPU                    Jobs Available
-                gpu-small     7   30.0G       ×       1 x nvidia-tesla-k80
-                gpu-large     7   60.0G       ×       1 x nvidia-tesla-v100
-                cpu-small     7    2.0G       ×                                           1
-                cpu-large     7   14.0G       ×                                           2"""  # noqa: E501, ignore line
+                Name       #CPU    Memory  Preemptible  GPU                    Jobs Available
+                gpu-small     7  30.0 GiB       ×       1 x nvidia-tesla-k80
+                gpu-large     7  60.0 GiB       ×       1 x nvidia-tesla-v100
+                cpu-small     7   2.0 GiB       ×                                           1
+                cpu-large     7  14.0 GiB       ×                                           2"""  # noqa: E501, ignore line
         )
 
 

--- a/tests/cli/formatters/test_disks.py
+++ b/tests/cli/formatters/test_disks.py
@@ -21,8 +21,8 @@ def test_disk_formatter() -> None:
     result = "\n".join(click.unstyle(line).rstrip() for line in fmtr(disk))
     assert result == textwrap.dedent(
         f"""\
-        Id    Storage  Uri                       Status  Created at   Last used
-        disk  11.9G    disk://cluster/user/disk  Ready   Mar 04 2017  Apr 04 2017"""
+        Id    Storage   Uri                       Status  Created at   Last used
+        disk  11.9 GiB  disk://cluster/user/disk  Ready   Mar 04 2017  Apr 04 2017"""
     )
 
 
@@ -65,11 +65,11 @@ def test_disks_formatter_short() -> None:
     result = "\n".join(click.unstyle(line).rstrip() for line in fmtr(disks))
     assert result == textwrap.dedent(
         f"""\
-        Id      Storage  Uri                         Status
-        disk-1  50.0G    disk://cluster/user/disk-1  Pending
-        disk-2  50.0M    disk://cluster/user/disk-2  Ready
-        disk-3  50.0K    disk://cluster/user/disk-3  Ready
-        disk-4  50B      disk://cluster/user/disk-4  Ready"""
+        Id      Storage   Uri                         Status
+        disk-1  50.0 GiB  disk://cluster/user/disk-1  Pending
+        disk-2  50.0 MiB  disk://cluster/user/disk-2  Ready
+        disk-3  50.0 KiB  disk://cluster/user/disk-3  Ready
+        disk-4  50 Bytes  disk://cluster/user/disk-4  Ready"""
     )
 
 
@@ -113,9 +113,9 @@ def test_disks_formatter_long() -> None:
     result = "\n".join(click.unstyle(line).rstrip() for line in fmtr(disks))
     assert result == textwrap.dedent(
         f"""\
-        Id      Storage  Uri                         Status   Created at   Last used
-        disk-1  50.0G    disk://cluster/user/disk-1  Pending  Mar 04 2017  Mar 08 2017
-        disk-2  50.0M    disk://cluster/user/disk-2  Ready    Apr 04 2017
-        disk-3  50.0K    disk://cluster/user/disk-3  Ready    May 04 2017
-        disk-4  50B      disk://cluster/user/disk-4  Ready    Jun 04 2017"""
+        Id      Storage   Uri                         Status   Created at   Last used
+        disk-1  50.0 GiB  disk://cluster/user/disk-1  Pending  Mar 04 2017  Mar 08 2017
+        disk-2  50.0 MiB  disk://cluster/user/disk-2  Ready    Apr 04 2017
+        disk-3  50.0 KiB  disk://cluster/user/disk-3  Ready    May 04 2017
+        disk-4  50 Bytes  disk://cluster/user/disk-4  Ready    Jun 04 2017"""
     )

--- a/tests/cli/formatters/test_jobs_formatters.py
+++ b/tests/cli/formatters/test_jobs_formatters.py
@@ -1961,7 +1961,7 @@ class TestResourcesFormatter:
         )
         resource_formatter = ResourcesFormatter()
         assert click.unstyle(resource_formatter(resources)) == (
-            "Resources:\n" "  Memory: 16.0M\n" "  CPU: 0.1"
+            "Resources:\n" "  Memory: 16.0 MiB\n" "  CPU: 0.1"
         )
 
     def test_gpu_container(self) -> None:
@@ -1977,7 +1977,7 @@ class TestResourcesFormatter:
         resource_formatter = ResourcesFormatter()
         assert click.unstyle(resource_formatter(resources)) == (
             "Resources:\n"
-            "  Memory: 1.0G\n"
+            "  Memory: 1.0 GiB\n"
             "  CPU: 2.0\n"
             "  GPU: 1.0 x nvidia-tesla-p4"
         )
@@ -1995,7 +1995,7 @@ class TestResourcesFormatter:
         resource_formatter = ResourcesFormatter()
         assert click.unstyle(resource_formatter(resources)) == (
             "Resources:\n"
-            "  Memory: 16.0M\n"
+            "  Memory: 16.0 MiB\n"
             "  CPU: 0.1\n"
             "  Additional: Extended SHM space"
         )
@@ -2013,7 +2013,7 @@ class TestResourcesFormatter:
         resource_formatter = ResourcesFormatter()
         assert click.unstyle(resource_formatter(resources=resources)) == (
             "Resources:\n"
-            "  Memory: 16.0M\n"
+            "  Memory: 16.0 MiB\n"
             "  CPU: 0.1\n"
             "  TPU: v2-8/1.14\n"
             "  Additional: Extended SHM space"

--- a/tests/cli/formatters/test_storage_formatters.py
+++ b/tests/cli/formatters/test_storage_formatters.py
@@ -415,11 +415,11 @@ class TestFilesFormatter:
 
         formatter = LongFilesFormatter(human_readable=True, color=False)
         assert list(formatter(self.files_and_folders)) == [
-            "-r    2.0 Ki 2018-01-01 03:00:00 File1",
-            "-r    1.0 Ki 2018-10-10 13:10:10 File2",
-            "-r 1000.0 Ki 2019-02-02 05:02:02 File3 with space",
-            "dm   0 Bytes 2017-03-03 06:03:03 Folder1",
-            "dm   0 Bytes 2017-03-03 06:03:02 1Folder with space",
+            "-r    2.0 KiB 2018-01-01 03:00:00 File1",
+            "-r    1.0 KiB 2018-10-10 13:10:10 File2",
+            "-r 1000.0 KiB 2019-02-02 05:02:02 File3 with space",
+            "dm    0 Bytes 2017-03-03 06:03:03 Folder1",
+            "dm    0 Bytes 2017-03-03 06:03:02 1Folder with space",
         ]
 
     def test_column_formatter(self) -> None:

--- a/tests/cli/formatters/test_storage_formatters.py
+++ b/tests/cli/formatters/test_storage_formatters.py
@@ -415,11 +415,11 @@ class TestFilesFormatter:
 
         formatter = LongFilesFormatter(human_readable=True, color=False)
         assert list(formatter(self.files_and_folders)) == [
-            "-r    2.0K 2018-01-01 03:00:00 File1",
-            "-r    1.0K 2018-10-10 13:10:10 File2",
-            "-r 1000.0K 2019-02-02 05:02:02 File3 with space",
-            "dm       0 2017-03-03 06:03:03 Folder1",
-            "dm       0 2017-03-03 06:03:02 1Folder with space",
+            "-r    2.0 Ki 2018-01-01 03:00:00 File1",
+            "-r    1.0 Ki 2018-10-10 13:10:10 File2",
+            "-r 1000.0 Ki 2019-02-02 05:02:02 File3 with space",
+            "dm   0 Bytes 2017-03-03 06:03:03 Folder1",
+            "dm   0 Bytes 2017-03-03 06:03:02 1Folder with space",
         ]
 
     def test_column_formatter(self) -> None:

--- a/tests/cli/test_parse_utils.py
+++ b/tests/cli/test_parse_utils.py
@@ -11,46 +11,45 @@ from neuromation.cli.parse_utils import (
 
 
 def test_parse_memory() -> None:
-    for value in ["1234", "   ", "", "-124", "M", "K", "k", "123B"]:
+    for value in ["   ", "", "-124", "-22M", "K", "k"]:
         with pytest.raises(ValueError, match=f"Unable parse value: {value}"):
             parse_memory(value)
 
-    assert parse_memory("1K") == 1024
-    assert parse_memory("2K") == 2048
-    assert parse_memory("1k") == 1024
-    assert parse_memory("2k") == 2048
-    assert parse_memory("1kB") == 1000
-    assert parse_memory("2kB") == 2000
-    assert parse_memory("1kb") == 1000
-    assert parse_memory("2kb") == 2000
+    assert parse_memory("100") == 100
+    assert parse_memory("200") == 200
 
-    assert parse_memory("42M") == 42 * 1024 ** 2
-    assert parse_memory("42MB") == 42 * 1000 ** 2
-    assert parse_memory("42Mb") == 42 * 1000 ** 2
+    assert parse_memory("1 K") == 1000
+    assert parse_memory("2  K") == 2000
+    assert parse_memory("1   k") == 1000
+    assert parse_memory("2 k") == 2000
+    assert parse_memory("1 Ki") == 1024
+    assert parse_memory("2   Ki") == 2048
+    assert parse_memory("1 KiB") == 1024
+    assert parse_memory("2 KiB") == 2048
 
-    assert parse_memory("42G") == 42 * 1024 ** 3
-    assert parse_memory("42GB") == 42 * 1000 ** 3
-    assert parse_memory("42Gb") == 42 * 1000 ** 3
+    assert parse_memory("42M") == 42 * 1000 ** 2
+    assert parse_memory("42Mi") == 42 * 1024 ** 2
+    assert parse_memory("42MiB") == 42 * 1024 ** 2
 
-    assert parse_memory("42T") == 42 * 1024 ** 4
-    assert parse_memory("42TB") == 42 * 1000 ** 4
-    assert parse_memory("42Tb") == 42 * 1000 ** 4
+    assert parse_memory("42G") == 42 * 1000 ** 3
+    assert parse_memory("42Gi") == 42 * 1024 ** 3
+    assert parse_memory("42GiB") == 42 * 1024 ** 3
 
-    assert parse_memory("42P") == 42 * 1024 ** 5
-    assert parse_memory("42PB") == 42 * 1000 ** 5
-    assert parse_memory("42Pb") == 42 * 1000 ** 5
+    assert parse_memory("42G") == 42 * 1000 ** 3
+    assert parse_memory("42Gi") == 42 * 1024 ** 3
+    assert parse_memory("42GiB") == 42 * 1024 ** 3
 
-    assert parse_memory("42E") == 42 * 1024 ** 6
-    assert parse_memory("42EB") == 42 * 1000 ** 6
-    assert parse_memory("42Eb") == 42 * 1000 ** 6
+    assert parse_memory("42T") == 42 * 1000 ** 4
+    assert parse_memory("42Ti") == 42 * 1024 ** 4
+    assert parse_memory("42TiB") == 42 * 1024 ** 4
 
-    assert parse_memory("42Z") == 42 * 1024 ** 7
-    assert parse_memory("42ZB") == 42 * 1000 ** 7
-    assert parse_memory("42Zb") == 42 * 1000 ** 7
+    assert parse_memory("42P") == 42 * 1000 ** 5
+    assert parse_memory("42Pi") == 42 * 1024 ** 5
+    assert parse_memory("42PiB") == 42 * 1024 ** 5
 
-    assert parse_memory("42Y") == 42 * 1024 ** 8
-    assert parse_memory("42YB") == 42 * 1000 ** 8
-    assert parse_memory("42Yb") == 42 * 1000 ** 8
+    assert parse_memory("42E") == 42 * 1000 ** 6
+    assert parse_memory("42Ei") == 42 * 1024 ** 6
+    assert parse_memory("42EiB") == 42 * 1024 ** 6
 
 
 def test_parse_columns_default() -> None:

--- a/tests/cli/test_storage_progress.py
+++ b/tests/cli/test_storage_progress.py
@@ -200,21 +200,30 @@ def test_tty_progress(capsys: Any, make_root: _MakeRoot) -> None:
     assert unstyle(report) == ["'file:///abc' ..."]
 
     report.start(StorageProgressStart(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [0.00%] 0B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [0.00%] 0 Bytes of 600 Bytes",
+    ]
 
     report.step(StorageProgressStep(src_f, dst_f, 300, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [50.00%] 300B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [50.00%] 300 Bytes of 600 Bytes",
+    ]
 
     report.step(StorageProgressStep(src_f, dst_f, 400, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [66.67%] 400B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [66.67%] 400 Bytes of 600 Bytes",
+    ]
 
     report.complete(StorageProgressComplete(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600 Bytes"]
 
     report.leave(StorageProgressLeaveDir(src, dst))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc' DONE",
     ]
 
@@ -244,63 +253,72 @@ def test_tty_nested(make_root: _MakeRoot) -> None:
     assert unstyle(report) == ["'file:///abc' ..."]
 
     report.start(StorageProgressStart(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [0.00%] 0B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [0.00%] 0 Bytes of 600 Bytes",
+    ]
 
     report.step(StorageProgressStep(src_f, dst_f, 300, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [50.00%] 300B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [50.00%] 300 Bytes of 600 Bytes",
+    ]
 
     report.step(StorageProgressStep(src_f, dst_f, 400, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' [66.67%] 400B of 600B"]
+    assert unstyle(report) == [
+        "'file:///abc' ...",
+        "'file.txt' [66.67%] 400 Bytes of 600 Bytes",
+    ]
 
     report.complete(StorageProgressComplete(src_f, dst_f, 600))
-    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600B"]
+    assert unstyle(report) == ["'file:///abc' ...", "'file.txt' 600 Bytes"]
 
     report.enter(StorageProgressEnterDir(src2, dst2))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
     ]
 
     report.start(StorageProgressStart(src2_f, dst2_f, 800))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
-        "'file.txt' [0.00%] 0B of 800B",
+        "'file.txt' [0.00%] 0 Bytes of 800 Bytes",
     ]
 
     report.step(StorageProgressStep(src2_f, dst2_f, 300, 800))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
-        "'file.txt' [37.50%] 300B of 800B",
+        "'file.txt' [37.50%] 300 Bytes of 800 Bytes",
     ]
 
     report.complete(StorageProgressComplete(src2_f, dst_f, 800))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
-        "'file.txt' 800B",
+        "'file.txt' 800 Bytes",
     ]
 
     report.leave(StorageProgressLeaveDir(src2, dst2))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
-        "'file.txt' 800B",
+        "'file.txt' 800 Bytes",
         "'file:///abc/cde' DONE",
     ]
 
     report.leave(StorageProgressLeaveDir(src, dst))
     assert unstyle(report) == [
         "'file:///abc' ...",
-        "'file.txt' 600B",
+        "'file.txt' 600 Bytes",
         "'file:///abc/cde' ...",
-        "'file.txt' 800B",
+        "'file.txt' 800 Bytes",
         "'file:///abc/cde' DONE",
         "'file:///abc' DONE",
     ]


### PR DESCRIPTION
Switches from GNU suffixes to SI suffixes. More information [here](https://en.wikipedia.org/wiki/Binary_prefix). In short:
Suffixes like **M** or **G** should be used for decimal quantifiers and **Mi** or **Gi** (pronounced Mebi and Gibi) should be used for binary quantifiers.