### PR TITLE
Added Keycloak support

### DIFF
--- a/neuromation/api/login.py
+++ b/neuromation/api/login.py
@@ -17,6 +17,7 @@ from typing import (
     Type,
     cast,
 )
+from urllib.parse import urlencode
 
 import aiohttp
 from aiohttp import ClientResponseError
@@ -313,7 +314,14 @@ class AuthTokenClient:
             client_id=self._client_id,
             redirect_uri=str(code.callback_url),
         )
-        async with self._client.post(self._url, json=payload) as resp:
+        async with self._client.post(
+            self._url,
+            headers={
+                "accept": "application/json",
+                "content-type": "application/x-www-form-urlencoded",
+            },
+            data=urlencode(payload),
+        ) as resp:
             try:
                 resp.raise_for_status()
             except ClientResponseError as exc:
@@ -331,7 +339,14 @@ class AuthTokenClient:
             refresh_token=token.refresh_token,
             client_id=self._client_id,
         )
-        async with self._client.post(self._url, json=payload) as resp:
+        async with self._client.post(
+            self._url,
+            headers={
+                "accept": "application/json",
+                "content-type": "application/x-www-form-urlencoded",
+            },
+            data=urlencode(payload),
+        ) as resp:
             try:
                 resp.raise_for_status()
             except ClientResponseError as exc:

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -2,6 +2,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 from unittest import mock
+from urllib.parse import parse_qsl
 
 import pytest
 import toml
@@ -541,7 +542,7 @@ async def test_refresh_token(
     aiohttp_server: _TestServerFactory, make_client: _MakeClient, token: str
 ) -> None:
     async def handler(request: web.Request) -> web.Response:
-        req = await request.json()
+        req = dict(parse_qsl(await request.text()))
         assert req == {
             "client_id": "CLIENT-ID",
             "grant_type": "refresh_token",

--- a/tests/api/test_login.py
+++ b/tests/api/test_login.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import AsyncIterator, Optional
 from unittest import mock
+from urllib.parse import parse_qsl
 
 import aiohttp
 import pytest
@@ -261,7 +262,9 @@ class _TestAuthHandler:
         raise HTTPFound(url)
 
     async def handle_token(self, request: Request) -> Response:
-        payload = await request.json()
+        assert request.headers["accept"] == "application/json"
+        assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+        payload = dict(parse_qsl(await request.text()))
         grant_type = payload["grant_type"]
         if grant_type == "authorization_code":
             assert payload == dict(


### PR DESCRIPTION
KeyCloak strictly requires requests to be `application/x-www-form-urlencoded` encoded. Auth0 supports (and even suggests) according to their docs this encoding as well: https://auth0.com/docs/api/authentication#get-token