### PR TITLE
Fix bug that caused to kill jobs from other tests

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -483,10 +483,7 @@ class Helper:
             raise
         out = proc.stdout
         err = proc.stderr
-        if any(
-            start in " ".join(arguments)
-            for start in ("submit", "job submit", "run", "job run")
-        ):
+        if any(run_cmd in arguments for run_cmd in ("submit", "run")):
             job_id = self.find_job_id(out)
             if job_id:
                 self._executed_jobs.append(job_id)


### PR DESCRIPTION
e2e/conftest.py uses some simple heuristic to catch `neuro run` like commands to kill jobs started by tests. Previously it joined all arguments by space and checked for some substrings. It did not working properly, because `'run'` is substring of `'jobs ls --status running'`.

Now it checks arguments directly, so it should work properly.