### PR TITLE
Do not import asynccontextmanager from neuromation.api.utils

### DIFF
--- a/neuromation/api/blob_storage.py
+++ b/neuromation/api/blob_storage.py
@@ -5,6 +5,7 @@ import hashlib
 import itertools
 import logging
 import re
+import sys
 import time
 from dataclasses import dataclass
 from email.utils import parsedate
@@ -48,7 +49,13 @@ from .file_filter import FileFilter, translate
 from .storage import _always, _has_magic, _magic_check, run_concurrently, run_progress
 from .url_utils import _extract_path, normalize_blob_path_uri, normalize_local_path_uri
 from .users import Action
-from .utils import NoPublicConstructor, asynccontextmanager, queue_calls, retries
+from .utils import NoPublicConstructor, queue_calls, retries
+
+
+if sys.version_info >= (3, 7):  # pragma: no cover
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
 
 
 log = logging.getLogger(__name__)

--- a/neuromation/api/core.py
+++ b/neuromation/api/core.py
@@ -4,6 +4,7 @@ import errno
 import json as jsonmodule
 import logging
 import sqlite3
+import sys
 import time
 from http.cookies import Morsel, SimpleCookie
 from types import SimpleNamespace
@@ -23,7 +24,12 @@ from .errors import (
     ServerNotAvailable,
 )
 from .tracing import gen_trace_id
-from .utils import asynccontextmanager
+
+
+if sys.version_info >= (3, 7):  # pragma: no cover
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
 
 
 log = logging.getLogger(__name__)

--- a/neuromation/api/jobs.py
+++ b/neuromation/api/jobs.py
@@ -49,7 +49,13 @@ from .url_utils import (
     normalize_secret_uri,
     normalize_storage_path_uri,
 )
-from .utils import NoPublicConstructor, asynccontextmanager
+from .utils import NoPublicConstructor
+
+
+if sys.version_info >= (3, 7):  # pragma: no cover
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
 
 
 log = logging.getLogger(__name__)

--- a/neuromation/api/login.py
+++ b/neuromation/api/login.py
@@ -4,6 +4,7 @@ import base64
 import errno
 import hashlib
 import secrets
+import sys
 import time
 from dataclasses import dataclass, field
 from typing import (
@@ -36,7 +37,12 @@ from jose import JWTError, jwt
 from yarl import URL
 
 from .errors import AuthException
-from .utils import asynccontextmanager
+
+
+if sys.version_info >= (3, 7):  # pragma: no cover
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
 
 
 def urlsafe_unpadded_b64encode(payload: bytes) -> str:

--- a/neuromation/api/utils.py
+++ b/neuromation/api/utils.py
@@ -23,15 +23,6 @@ import aiohttp
 from neuromation.api.errors import ConfigError
 
 
-if sys.version_info >= (3, 7):  # pragma: no cover
-    from contextlib import asynccontextmanager
-else:
-    from async_generator import asynccontextmanager
-
-# Silence flake8 warning:
-#   'async_generator.asynccontextmanager' imported but unused
-asynccontextmanager
-
 _T = TypeVar("_T")
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -53,7 +53,13 @@ from neuromation.api import (
     get as api_get,
     login_with_token,
 )
-from neuromation.api.utils import asynccontextmanager
+
+
+if sys.version_info >= (3, 7):  # pragma: no cover
+    from contextlib import asynccontextmanager
+else:
+    from async_generator import asynccontextmanager
+
 from neuromation.cli.asyncio_utils import run
 from neuromation.cli.utils import resolve_job
 from tests.e2e.utils import FILE_SIZE_B, NGINX_IMAGE_NAME, JobWaitStateStopReached


### PR DESCRIPTION
`asynccontextmanager` is no longer used in `neuromation.api.utils` itself.