### PR TITLE
Fix progress test flakes because of autorefresh

### DIFF
--- a/neuromation/cli/formatters/storage.py
+++ b/neuromation/cli/formatters/storage.py
@@ -581,10 +581,14 @@ class BaseStorageProgress(AbstractRecursiveFileProgress, ABC):
 
 
 def create_storage_progress(
-    root: Root, show_progress: bool, *, get_time: GetTimeCallable = time.monotonic
+    root: Root,
+    show_progress: bool,
+    *,
+    get_time: GetTimeCallable = time.monotonic,
+    auto_refresh: bool = True,  # only disabled in test
 ) -> BaseStorageProgress:
     if show_progress:
-        return TTYProgress(root, get_time=get_time)
+        return TTYProgress(root, get_time=get_time, auto_refresh=auto_refresh)
     else:
         return StreamProgress(root)
 
@@ -651,7 +655,11 @@ class TTYProgress(BaseStorageProgress):
     time_factory = staticmethod(monotonic)
 
     def __init__(
-        self, root: Root, *, get_time: GetTimeCallable = time.monotonic
+        self,
+        root: Root,
+        *,
+        get_time: GetTimeCallable = time.monotonic,
+        auto_refresh: bool = True,
     ) -> None:
         self.painter = get_painter(root.color)
         self._root = root
@@ -663,7 +671,7 @@ class TTYProgress(BaseStorageProgress):
             DownloadColumn(),
             TransferSpeedColumn(),
             console=root.console,
-            auto_refresh=True,
+            auto_refresh=auto_refresh,
             transient=True,
             get_time=get_time,
         )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -346,7 +346,7 @@ def rich_cmp(request: Any) -> Callable[..., None]:
         if isinstance(src, io.StringIO):
             plugin.check_io(ref, src)
         elif isinstance(src, Console):
-            if isinstance(src.file, io.StringIO):
+            if not isinstance(src.file, io.StringIO):
                 plugin.check_io(ref, src.file)
             else:
                 buf = src.export_text(clear=True, styles=True)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -346,7 +346,7 @@ def rich_cmp(request: Any) -> Callable[..., None]:
         if isinstance(src, io.StringIO):
             plugin.check_io(ref, src)
         elif isinstance(src, Console):
-            if not isinstance(src.file, io.StringIO):
+            if isinstance(src.file, io.StringIO):
                 plugin.check_io(ref, src.file)
             else:
                 buf = src.export_text(clear=True, styles=True)

--- a/tests/cli/test_storage_progress.py
+++ b/tests/cli/test_storage_progress.py
@@ -124,7 +124,9 @@ def test_progress(
     time_ctl: TimeCtl,
 ) -> None:
     root = make_root(color, tty, verbose)
-    report = create_storage_progress(root, show_progress, get_time=time_ctl.get_time)
+    report = create_storage_progress(
+        root, show_progress, get_time=time_ctl.get_time, auto_refresh=False
+    )
     src = URL("file:///abc")
     dst = URL("storage:xyz")
 
@@ -175,7 +177,9 @@ def test_fail(
     time_ctl: TimeCtl,
 ) -> None:
     root = make_root(color, tty, verbose)
-    report = create_storage_progress(root, show_progress, get_time=time_ctl.get_time)
+    report = create_storage_progress(
+        root, show_progress, get_time=time_ctl.get_time, auto_refresh=False
+    )
     src = URL("file:///abc")
     dst = URL("storage:xyz")
     with report.begin(src, dst):
@@ -204,7 +208,9 @@ def test_nested(
     time_ctl: TimeCtl,
 ) -> None:
     root = make_root(color, tty, verbose)
-    report = create_storage_progress(root, show_progress, get_time=time_ctl.get_time)
+    report = create_storage_progress(
+        root, show_progress, get_time=time_ctl.get_time, auto_refresh=False
+    )
     src = URL("file:///abc")
     dst = URL("storage:xyz")
     src_f = URL("file:///abc/file.txt")


### PR DESCRIPTION
I do not want to disable auto refresh in general because without it `TransferSpeedColumn` can do huge jumps.