### PR TITLE
Add `-f` flag to `neuro image rm`

### DIFF
--- a/CHANGELOG.D/1828.feature
+++ b/CHANGELOG.D/1828.feature
@@ -1,0 +1,1 @@
+Add `-f` flag to `neuro image rm` to force delete images that have multiple tag references

--- a/CLI.md
+++ b/CLI.md
@@ -1210,6 +1210,7 @@ neuro image rm image:myimage:latest
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_-f_|Force deletion of all tags referencing the image.|
 
 
 

--- a/neuromation/api/images.py
+++ b/neuromation/api/images.py
@@ -124,6 +124,15 @@ class Images(metaclass=NoPublicConstructor):
         async with self._core.request("DELETE", url, auth=auth) as resp:
             assert resp
 
+    async def rm_tag(self, image: RemoteImage, tag: str) -> None:
+        name = f"{image.owner}/{image.name}"
+        auth = await self._config._registry_auth()
+        url = self._registry_url / name / "tags" / tag
+        print(url)
+        async with self._core.request("DELETE", url, auth=auth) as resp:
+            assert resp
+            print(await resp.json())
+
     async def pull(
         self,
         remote: RemoteImage,

--- a/neuromation/api/images.py
+++ b/neuromation/api/images.py
@@ -124,15 +124,6 @@ class Images(metaclass=NoPublicConstructor):
         async with self._core.request("DELETE", url, auth=auth) as resp:
             assert resp
 
-    async def rm_tag(self, image: RemoteImage, tag: str) -> None:
-        name = f"{image.owner}/{image.name}"
-        auth = await self._config._registry_auth()
-        url = self._registry_url / name / "tags" / tag
-        print(url)
-        async with self._core.request("DELETE", url, auth=auth) as resp:
-            assert resp
-            print(await resp.json())
-
     async def pull(
         self,
         remote: RemoteImage,


### PR DESCRIPTION
Closes #1828 

If there's more than 1 tag for image, the CLI checks whether any other tags reference the same image and if that's the case refuses to delete image without the `-f` flag.