### PR TITLE
Fix parse_resource_for_sharing_image for "image:" and "image:/"

### DIFF
--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -32,7 +32,7 @@ import humanize
 from click.types import convert_type
 from yarl import URL
 
-from neuromation.api import Action, Client, JobStatus, TagOption, Volume
+from neuromation.api import Action, Client, JobStatus, Volume
 from neuromation.api.url_utils import uri_from_cli
 
 from .parse_utils import parse_timedelta
@@ -477,16 +477,15 @@ def parse_resource_for_sharing(uri: str, root: Root) -> URL:
     """Parses the neuromation resource URI string.
     Available schemes: storage, image, job. For image URIs, tags are not allowed.
     """
-    if uri.startswith("image:"):
-        image = root.client.parse.remote_image(uri, tag_option=TagOption.DENY)
-        uri = str(image)
-
     uri_res = uri_from_cli(
         uri,
         root.client.username,
         root.client.cluster_name,
         allowed_schemes=SHARE_SCHEMES,
     )
+    if uri_res.scheme == "image" and ":" in uri_res.path:
+        raise ValueError("tag is not allowed")
+
     # URI's for object storage can only operate on bucket level
     if uri_res.scheme == "blob" and "/" in uri_res.path.strip("/"):
         raise ValueError("Only bucket level permissions are supported for Blob Storage")

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -507,10 +507,40 @@ def test_parse_resource_for_sharing_image_no_tag(root: Root) -> None:
     )
 
 
+def test_parse_resource_for_sharing_image_non_ascii(root: Root) -> None:
+    uri = "image:образ"
+    parsed = parse_resource_for_sharing(uri, root)
+    assert parsed == URL(
+        f"image://{root.client.cluster_name}/{root.client.username}/образ"
+    )
+    assert parsed.path == f"/{root.client.username}/образ"
+
+
+def test_parse_resource_for_sharing_image_percent_encoded(root: Root) -> None:
+    uri = "image:%252d%3f%23"
+    parsed = parse_resource_for_sharing(uri, root)
+    assert parsed == URL(
+        f"image://{root.client.cluster_name}/{root.client.username}/%252d%3f%23"
+    )
+    assert parsed.path == f"/{root.client.username}/%2d?#"
+
+
 def test_parse_resource_for_sharing_image_with_tag_fail(root: Root) -> None:
-    uri = "image://~/ubuntu:latest"
+    uri = "image:ubuntu:latest"
     with pytest.raises(ValueError, match="tag is not allowed"):
         parse_resource_for_sharing(uri, root)
+
+
+def test_parse_resource_for_sharing_all_user_images(root: Root) -> None:
+    uri = "image:/otheruser"
+    parsed = parse_resource_for_sharing(uri, root)
+    assert parsed == URL(f"image://{root.client.cluster_name}/otheruser")
+
+
+def _test_parse_resource_for_sharing_all_cluster_images(root: Root) -> None:
+    uri = "image://"
+    parsed = parse_resource_for_sharing(uri, root)
+    assert parsed == URL(f"image://{root.client.cluster_name}/otheruser")
 
 
 def test_parse_resource_for_sharing_no_scheme(root: Root) -> None:


### PR DESCRIPTION
Closes #1751.