### PR TITLE
Remove support of deprecated `-s all` in `neuro ps`

### DIFF
--- a/CHANGELOG.D/1883.feature
+++ b/CHANGELOG.D/1883.feature
@@ -1,0 +1,1 @@
+Removed support of deprecated `--status=all` in `neuro ps`. Use `--all` instead.

--- a/CLI.md
+++ b/CLI.md
@@ -568,7 +568,7 @@ Name | Description|
 |_\-o, --owner TEXT_|Filter out jobs by owner \(multiple option). Supports `ME` option to filter by the current user.|
 |_\-q, --quiet_|Run command in quiet mode \(DEPRECATED)|
 |_--since DATE_|Show jobs created after a specific date \(including).|
-|_\-s, --status \[pending &#124; suspended &#124; running &#124; succeeded &#124; failed &#124; cancelled &#124; all]_|Filter out jobs by status \(multiple option). Note: option `all` is deprecated, use `neuro ps -a` instead.|
+|_\-s, --status \[pending &#124; suspended &#124; running &#124; succeeded &#124; failed &#124; cancelled]_|Filter out jobs by status \(multiple option).|
 |_\-t, --tag TAG_|Filter out jobs by tag \(multiple option)|
 |_--until DATE_|Show jobs created before a specific date \(including).|
 |_\-w, --wide_|Do not cut long lines for terminal width.|
@@ -2266,7 +2266,7 @@ Name | Description|
 |_\-o, --owner TEXT_|Filter out jobs by owner \(multiple option). Supports `ME` option to filter by the current user.|
 |_\-q, --quiet_|Run command in quiet mode \(DEPRECATED)|
 |_--since DATE_|Show jobs created after a specific date \(including).|
-|_\-s, --status \[pending &#124; suspended &#124; running &#124; succeeded &#124; failed &#124; cancelled &#124; all]_|Filter out jobs by status \(multiple option). Note: option `all` is deprecated, use `neuro ps -a` instead.|
+|_\-s, --status \[pending &#124; suspended &#124; running &#124; succeeded &#124; failed &#124; cancelled]_|Filter out jobs by status \(multiple option).|
 |_\-t, --tag TAG_|Filter out jobs by tag \(multiple option)|
 |_--until DATE_|Show jobs created before a specific date \(including).|
 |_\-w, --wide_|Do not cut long lines for terminal width.|

--- a/neuro-cli/tests/unit/test_job.py
+++ b/neuro-cli/tests/unit/test_job.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Tuple
 
-import click
 import pytest
 import toml
 from yarl import URL
@@ -20,32 +19,15 @@ _MakeClient = Callable[..., Client]
 
 
 @pytest.mark.parametrize("statuses", [("all",), ("all", "failed", "succeeded")])
-def test_calc_statuses__contains_all__all_statuses_true(statuses: Tuple[str]) -> None:
+def test_calc_statuses__contains_all(statuses: Tuple[str]) -> None:
     with pytest.raises(
-        click.UsageError,
-        match="Parameters `-a/--all` and " "`-s all/--status=all` are incompatible$",
+        ValueError,
+        match="'all' is not a valid JobStatus",
     ):
-        calc_statuses(statuses, all=True)
+        calc_statuses(statuses, all=False)
 
 
-@pytest.mark.parametrize("statuses", [("all",), ("all", "failed", "succeeded")])
-def test_calc_statuses__contains_all__all_statuses_false(
-    capsys: Any, caplog: Any, statuses: Tuple[str]
-) -> None:
-    calc_statuses(statuses, all=False)
-    std = capsys.readouterr()
-    assert not std.out
-    assert std.err == (
-        "DeprecationWarning: "
-        "Option `-s all/--status=all` is deprecated. "
-        "Please use `-a/--all` instead.\n"
-    )
-    assert not caplog.text
-
-
-def test_calc_statuses__not_contains_all__all_statuses_true(
-    capsys: Any, caplog: Any
-) -> None:
+def test_calc_statuses__all_statuses_true(capsys: Any, caplog: Any) -> None:
     assert calc_statuses(["succeeded", "pending"], all=True) == set()
     std = capsys.readouterr()
     assert not std.out
@@ -57,9 +39,7 @@ def test_calc_statuses__not_contains_all__all_statuses_true(
     assert warning in caplog.text
 
 
-def test_calc_statuses__not_contains_all__all_statuses_true__quiet_mode(
-    capsys: Any, caplog: Any
-) -> None:
+def test_calc_statuses__all_statuses_true__quiet_mode(capsys: Any, caplog: Any) -> None:
     caplog.set_level(logging.ERROR)
 
     assert calc_statuses(["succeeded", "pending"], all=True) == set()
@@ -69,9 +49,7 @@ def test_calc_statuses__not_contains_all__all_statuses_true__quiet_mode(
     assert not caplog.text
 
 
-def test_calc_statuses__not_contains_all__all_statuses_false(
-    capsys: Any, caplog: Any
-) -> None:
+def test_calc_statuses__all_statuses_false(capsys: Any, caplog: Any) -> None:
     assert calc_statuses(["succeeded", "pending"], all=False) == {
         JobStatus.SUCCEEDED,
         JobStatus.PENDING,


### PR DESCRIPTION
`neuro ps -a` can be used instead of deprecated `neuro ps -s all`.

Closes #1883.