### PR TITLE
Fix output on Windows with pager

### DIFF
--- a/CHANGELOG.D/1909.bugfix
+++ b/CHANGELOG.D/1909.bugfix
@@ -1,0 +1,1 @@
+Fixed output on Windows with pager.

--- a/neuro-cli/src/neuro_cli/root.py
+++ b/neuro-cli/src/neuro_cli/root.py
@@ -96,6 +96,8 @@ class Root:
             self.console = Console(
                 color_system="auto" if self.color else None,
                 force_terminal=self.tty,
+                markup=False,
+                emoji=False,
                 highlight=False,
                 log_path=False,
                 width=2048,

--- a/neuro-cli/src/neuro_cli/root.py
+++ b/neuro-cli/src/neuro_cli/root.py
@@ -313,6 +313,9 @@ class Root:
             sys.stdout.flush()
 
     def pager(self) -> PagerContext:
+        if sys.platform == "win32":
+            # Default Windows pager (more) does not support ANSI sequences.
+            return self.console.pager(MaybePager(self.console))
         return self.console.pager(MaybePager(self.console), styles=True, links=True)
 
     def print(self, *objects: Any, err: bool = False, **kwargs: Any) -> None:


### PR DESCRIPTION
Since the default Windows pager does not support ANSI sequences,
strip styling when output via pager on Windows.

Closes #1909.