### PR TITLE
Enable soft wrap for generate-run-command

### DIFF
--- a/CHANGELOG.D/2034.bugfix
+++ b/CHANGELOG.D/2034.bugfix
@@ -1,0 +1,1 @@
+Do not add implicit '\n's to `neuro job generate_run_command <job-id>` command output.

--- a/neuro-cli/src/neuro_cli/job.py
+++ b/neuro-cli/src/neuro_cli/job.py
@@ -1065,7 +1065,7 @@ async def generate_run_command(root: Root, job: str) -> None:
     )
     job_description = await root.client.jobs.status(id)
     args = _job_to_cli_args(job_description)
-    root.print(f"neuro run " + " ".join(args))
+    root.print(f"neuro run " + " ".join(args), soft_wrap=True)
 
 
 job.add_command(run)


### PR DESCRIPTION
If not enabled, Rich will add `\n`s implicitly and one is not able to `copy -> paste -> redact -> run` command in terminal.