### PR TITLE
Add option --share in `neuro job run`

### DIFF
--- a/CHANGELOG.D/2079.feature
+++ b/CHANGELOG.D/2079.feature
@@ -1,0 +1,1 @@
+Added option `--share` in `neuro job run`. It allows to share a created job with specified user or role.

--- a/CLI.md
+++ b/CLI.md
@@ -528,6 +528,7 @@ Name | Description|
 |_\-q, --quiet_|Run command in quiet mode \(DEPRECATED)|
 |_\--restart \[never &#124; on-failure &#124; always]_|Restart policy to apply when a job exits  \[default: never]|
 |_\--schedule-timeout TIMEDELTA_|Optional job schedule timeout in the format '3m4s' \(some parts may be missing).|
+|_--share USER_|Share job write permissions to user or role.|
 |_--tag TAG_|Optional job tag, multiple values allowed|
 |_\-t, --tty / -T, --no-tty_|Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script.|
 |_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files.|
@@ -2279,6 +2280,7 @@ Name | Description|
 |_\-q, --quiet_|Run command in quiet mode \(DEPRECATED)|
 |_\--restart \[never &#124; on-failure &#124; always]_|Restart policy to apply when a job exits  \[default: never]|
 |_\--schedule-timeout TIMEDELTA_|Optional job schedule timeout in the format '3m4s' \(some parts may be missing).|
+|_--share USER_|Share job write permissions to user or role.|
 |_--tag TAG_|Optional job tag, multiple values allowed|
 |_\-t, --tty / -T, --no-tty_|Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script.|
 |_\-v, --volume MOUNT_|Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files.|

--- a/neuro-cli/docs/job.md
+++ b/neuro-cli/docs/job.md
@@ -86,6 +86,7 @@ $ neuro run -s cpu-small image:my-ubuntu:latest --entrypoint=/script.sh arg1 arg
 | _-q, --quiet_ | Run command in quiet mode \(DEPRECATED\) |
 | _--restart \[never &#124; on-failure &#124; always\]_ | Restart policy to apply when a job exits  _\[default: never\]_ |
 | _--schedule-timeout TIMEDELTA_ | Optional job schedule timeout in the format '3m4s' \(some parts may be missing\). |
+| _--share USER_ | Share job write permissions to user or role. |
 | _--tag TAG_ | Optional job tag, multiple values allowed |
 | _-t, --tty / -T, --no-tty_ | Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script. |
 | _-v, --volume MOUNT_ | Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files. |

--- a/neuro-cli/docs/shortcuts.md
+++ b/neuro-cli/docs/shortcuts.md
@@ -83,6 +83,7 @@ $ neuro run -s cpu-small image:my-ubuntu:latest --entrypoint=/script.sh arg1 arg
 | _-q, --quiet_ | Run command in quiet mode \(DEPRECATED\) |
 | _--restart \[never &#124; on-failure &#124; always\]_ | Restart policy to apply when a job exits  _\[default: never\]_ |
 | _--schedule-timeout TIMEDELTA_ | Optional job schedule timeout in the format '3m4s' \(some parts may be missing\). |
+| _--share USER_ | Share job write permissions to user or role. |
 | _--tag TAG_ | Optional job tag, multiple values allowed |
 | _-t, --tty / -T, --no-tty_ | Allocate a TTY, can be useful for interactive jobs. By default is on if the command is executed from a terminal, non-tty mode is used if executed from a script. |
 | _-v, --volume MOUNT_ | Mounts directory from vault into container. Use multiple options to mount more than one volume. See `neuro help secrets` for information about passing secrets as mounted files. |

--- a/neuro-cli/tests/e2e/test_e2e_jobs.py
+++ b/neuro-cli/tests/e2e/test_e2e_jobs.py
@@ -825,6 +825,32 @@ def test_job_run_browse(helper: Helper, fakebrowser: Any) -> None:
 
 
 @pytest.mark.e2e
+def test_job_run_share(helper: Helper, fakebrowser: Any) -> None:
+    another_test_user = "test2"
+    # Run a new job
+    captured = helper.run_cli(
+        [
+            "-q",
+            "job",
+            "run",
+            "--no-wait-start",
+            "--share",
+            another_test_user,
+            UBUNTU_IMAGE_NAME,
+            "true",
+        ]
+    )
+    job_id = captured.out.strip()
+
+    uri = f"job://{helper.cluster_name}/{helper.username}/{job_id}"
+    captured = helper.run_cli(["acl", "list", "--full-uri", "--shared", uri])
+    result = [line.split() for line in captured.out.splitlines()]
+    assert [uri, "write", another_test_user] in result
+
+    helper.run_cli(["acl", "revoke", uri, another_test_user])
+
+
+@pytest.mark.e2e
 def test_job_submit_no_detach_failure(helper: Helper) -> None:
     # Run a new job
     with pytest.raises(subprocess.CalledProcessError) as exc_info:


### PR DESCRIPTION
It shares newly created job with specified user or role.
It can help in neuro-flow.