### PR TITLE
Support other clusters in jobs commands

### DIFF
--- a/CHANGELOG.D/2116.feature
+++ b/CHANGELOG.D/2116.feature
@@ -1,0 +1,1 @@
+All job related commands support now jobs on other clusters. Commands `neuro exec`, `neuro port-forward`, `neuro logs` and `neuro job save` only support jobs on other clusters if they are specified by URI (jobs on the current cluster can be also specified by bare ID or name).

--- a/neuro-cli/src/neuro_cli/config.py
+++ b/neuro-cli/src/neuro_cli/config.py
@@ -33,9 +33,10 @@ async def show(root: Root) -> None:
     """
     Print current settings.
     """
+    cluster_name = root.client.config.cluster_name
     fmt = ConfigFormatter()
     try:
-        jobs_capacity = await root.client.jobs.get_capacity()
+        jobs_capacity = await root.client.jobs.get_capacity(cluster_name=cluster_name)
     except ClientConnectionError:
         jobs_capacity = {}
     root.print(fmt(root.client.config, jobs_capacity))

--- a/neuro-cli/src/neuro_cli/job.py
+++ b/neuro-cli/src/neuro_cli/job.py
@@ -79,6 +79,7 @@ from .utils import (
     group,
     option,
     resolve_job,
+    resolve_job_ex,
     volume_to_verbose_str,
 )
 
@@ -150,7 +151,7 @@ async def exec(
     neuro exec --no-tty my-job ls -l
     """
     real_cmd = _parse_cmd(cmd)
-    job = await resolve_job(
+    job, cluster_name = await resolve_job_ex(
         job,
         client=root.client,
         status=JobStatus.active_items(),
@@ -158,7 +159,7 @@ async def exec(
     if tty is None:
         tty = root.tty
     _check_tty(root, tty)
-    await process_exec(root, job, real_cmd, tty)
+    await process_exec(root, job, real_cmd, tty, cluster_name=cluster_name)
 
 
 @command()
@@ -205,7 +206,7 @@ async def port_forward(
             fg="red",
             err=True,
         )
-    job_id = await resolve_job(
+    job_id, cluster_name = await resolve_job_ex(
         job,
         client=root.client,
         status=JobStatus.active_items(),
@@ -217,7 +218,9 @@ async def port_forward(
                 f"to port {job_port} of {job_id}"
             )
             await stack.enter_async_context(
-                root.client.jobs.port_forward(job_id, local_port, job_port)
+                root.client.jobs.port_forward(
+                    job_id, local_port, job_port, cluster_name=cluster_name
+                )
             )
 
         root.print("Press ^C to stop forwarding")
@@ -234,12 +237,12 @@ async def logs(root: Root, job: str) -> None:
     """
     Print the logs for a job.
     """
-    id = await resolve_job(
+    id, cluster_name = await resolve_job_ex(
         job,
         client=root.client,
         status=JobStatus.items(),
     )
-    await process_logs(root, id, None)
+    await process_logs(root, id, None, cluster_name=cluster_name)
 
 
 @command()
@@ -270,7 +273,13 @@ async def attach(root: Root, job: str, port_forward: List[Tuple[int, int]]) -> N
     tty = status.container.tty
     _check_tty(root, tty)
 
-    await process_attach(root, status, tty=tty, logs=False, port_forward=port_forward)
+    await process_attach(
+        root,
+        status,
+        tty=tty,
+        logs=False,
+        port_forward=port_forward,
+    )
 
 
 @command()
@@ -390,6 +399,7 @@ async def ls(
         owners.remove("ME")
         owners.add(root.client.config.username)
     tags = set(tag)
+    cluster_name = root.client.config.cluster_name
     jobs = root.client.jobs.list(
         statuses=statuses,
         name=name,
@@ -398,6 +408,7 @@ async def ls(
         since=_parse_date(since),
         until=_parse_date(until),
         reverse=recent_first,
+        cluster_name=cluster_name,
     )
 
     # client-side filtering
@@ -621,6 +632,7 @@ async def top(
 
     sort_keys = parse_sort_keys(sort)
     format = await calc_top_columns(root.client, format)
+    cluster_name = root.client.config.cluster_name
 
     observed: Set[str] = set()
     loop = asyncio.get_event_loop()
@@ -676,6 +688,7 @@ async def top(
                     tags=tags,
                     since=since_dt,
                     until=until_dt,
+                    cluster_name=cluster_name,
                 )
 
                 # client-side filtering
@@ -699,7 +712,9 @@ async def top(
 
     async def poller(job: JobDescription) -> None:
         try:
-            async for info in root.client.jobs.top(job.id):
+            async for info in root.client.jobs.top(
+                job.id, cluster_name=job.cluster_name
+            ):
                 formatter.update(job, info)
                 await asyncio.sleep(0)
         except ValueError:
@@ -748,14 +763,16 @@ async def save(root: Root, job: str, image: RemoteImage) -> None:
     neuro job save my-favourite-job image:ubuntu-patched:v1
     neuro job save my-favourite-job image://bob/ubuntu-patched
     """
-    id = await resolve_job(
+    id, cluster_name = await resolve_job_ex(
         job,
         client=root.client,
         status=JobStatus.items(),
     )
     progress = DockerImageProgress.create(console=root.console, quiet=root.quiet)
     with contextlib.closing(progress):
-        await root.client.jobs.save(id, image, progress=progress)
+        await root.client.jobs.save(
+            id, image, progress=progress, cluster_name=cluster_name
+        )
     root.print(image)
 
 
@@ -1063,6 +1080,7 @@ async def run(
         schedule_timeout=schedule_timeout,
         privileged=privileged,
         share=share,
+        cluster_name=root.client.cluster_name,
     )
 
 
@@ -1136,6 +1154,7 @@ async def run_job(
     schedule_timeout: Optional[str],
     privileged: bool,
     share: Sequence[str],
+    cluster_name: str,
 ) -> JobDescription:
     if http_auth is None:
         http_auth = True
@@ -1205,7 +1224,7 @@ async def run_job(
                 f"{old_env_name} is already set to {env_dict[old_env_name]}"
             )
 
-        env_var, secret_volume = await upload_and_map_config(root)
+        env_var, secret_volume = await upload_and_map_config(root, cluster_name)
         env_dict[old_env_name] = env_var
         volumes.append(secret_volume)
         # End of compatibility layer
@@ -1260,7 +1279,13 @@ async def run_job(
         await browse_job(root, job)
 
     if not detach:
-        await process_attach(root, job, tty=tty, logs=True, port_forward=port_forward)
+        await process_attach(
+            root,
+            job,
+            tty=tty,
+            logs=True,
+            port_forward=port_forward,
+        )
 
     return job
 
@@ -1273,13 +1298,13 @@ def _parse_cmd(cmd: Sequence[str]) -> str:
     return real_cmd
 
 
-async def upload_and_map_config(root: Root) -> Tuple[str, Volume]:
+async def upload_and_map_config(root: Root, cluster_name: str) -> Tuple[str, Volume]:
 
     # store the Neuro CLI config on the storage under some random path
     nmrc_path = URL(root.config_path.expanduser().resolve().as_uri())
     random_nmrc_filename = f"{uuid.uuid4()}-cfg"
     storage_nmrc_folder = URL(
-        f"storage://{root.client.cluster_name}/{root.client.username}/.neuro/"
+        f"storage://{cluster_name}/{root.client.username}/.neuro/"
     )
     storage_nmrc_path = storage_nmrc_folder / random_nmrc_filename
     local_nmrc_folder = f"{STORAGE_MOUNTPOINT}/.neuro/"

--- a/neuro-cli/tests/unit/conftest.py
+++ b/neuro-cli/tests/unit/conftest.py
@@ -59,6 +59,21 @@ def nmrc_path(tmp_path: Path, token: str, auth_config: _AuthConfig) -> Path:
         },
         name="default",
     )
+    cluster2_config = Cluster(
+        registry_url=URL("https://registry2-dev.neu.ro"),
+        storage_url=URL("https://storage2-dev.neu.ro"),
+        blob_storage_url=URL("https://blob-storage2-dev.neu.ro"),
+        users_url=URL("https://users2-dev.neu.ro"),
+        monitoring_url=URL("https://monitoring2-dev.neu.ro"),
+        secrets_url=URL("https://secrets2-dev.neu.ro"),
+        disks_url=URL("https://disks2-dev.neu.ro"),
+        presets={
+            "cpu-small": Preset(
+                credits_per_hour=Decimal("10"), cpu=7, memory_mb=2 * 1024
+            ),
+        },
+        name="other",
+    )
     config = _ConfigData(
         auth_config=auth_config,
         auth_token=_AuthToken.create_non_expiring(token),
@@ -66,7 +81,10 @@ def nmrc_path(tmp_path: Path, token: str, auth_config: _AuthConfig) -> Path:
         admin_url=URL("https://dev.neu.ro/apis/admin/v1"),
         version=__version__,
         cluster_name="default",
-        clusters={cluster_config.name: cluster_config},
+        clusters={
+            cluster_config.name: cluster_config,
+            cluster2_config.name: cluster2_config,
+        },
     )
     Factory(nmrc_path)._save(config)
     return nmrc_path

--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -21,6 +21,7 @@ Jobs
                       stdin: bool = False, \
                       stdout: bool = False, \
                       stderr: bool = False, \
+                      cluster_name: Optional[str] = None, \
                  ) -> AsyncContextManager[StdStream]
       :async-with:
 
@@ -34,11 +35,16 @@ Jobs
 
       :param bool stderr: ``True`` to attach stderr, default is ``False``.
 
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
       :return: Asynchronous context manager which can be used to access
                stdin/stdout/stderr, see :class:`StdStream` for details.
 
    .. comethod:: exec_create(id: str, cmd: List[str], *, \
                       tty: bool = False, \
+                      cluster_name: Optional[str] = None, \
                  ) -> str
 
       Create an exec session to run a command in a running job.
@@ -51,9 +57,15 @@ Jobs
       :param bool tty: ``True`` if :term:`tty` mode is requested, default is
                        ``False``.
 
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
       :return: Exec session id (:class:`str`).
 
-   .. comethod:: exec_inspect(id: str, exec_id: str) -> ExecInspect
+   .. comethod:: exec_inspect(id: str, exec_id: str, *. \
+                              cluster_name: Optional[str] = None, \
+                 ) -> ExecInspect
 
       Get exec session info.
 
@@ -75,7 +87,13 @@ Jobs
 
       :param int h: New screen height.
 
-   .. comethod:: exec_start(id: str, exec_id: str) -> StdStream
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
+   .. comethod:: exec_start(id: str, exec_id: str, *, \
+                            cluster_name: Optional[str] = None, \
+                 ) -> StdStream
       :async-with:
 
       Start an exec session, get access to session's stdin/stdout/stderr.
@@ -84,12 +102,18 @@ Jobs
 
       :param str exec_id: exec id.
 
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
       :return: Asynchronous context manager which can be used to access
                stdin/stdout/stderr, see :class:`StdStream` for details.
 
-   .. comethod:: get_capacity() -> Mapping[str, int]
+   .. comethod:: get_capacity(*, \
+                             cluster_name: Optional[str] = None, \
+                 ) -> Mapping[str, int]
 
-      Get counts of available job for current cluster for each available preset.
+      Get counts of available job for specified cluster for each available preset.
 
       The returned numbers reflect the remaining *cluster capacity*. In other words, it
       displays how many concurrent jobs for each preset can be started at the moment of
@@ -97,6 +121,10 @@ Jobs
 
       The returned capacity is an approximation, the real value can differ if already
       running jobs are finished or another user starts own jobs at the same time.
+
+      :param str cluster_name: cluster for which the request is performed.
+
+                               ``None`` means the current cluster (default).
 
       :return: A mapping of *preset_name* to *count*, where *count* is a number of
                concurrent jobs that can be executed using *preset_name*.
@@ -115,6 +143,7 @@ Jobs
                       until: Optional[datetime] = None, \
                       reverse: bool = False, \
                       limit: Optional[int] = None, \
+                      cluster_name: Optional[str] = None, \
                  ) -> AsyncIterator[JobDescription]
       :async-for:
 
@@ -181,10 +210,16 @@ Jobs
 
                         ``None`` means no limit (default).
 
+      :param str cluster_name: list jobs on specified cluster.
+
+                               ``None`` means the current cluster (default).
+
       :return: asynchronous iterator which emits :class:`JobDescription` objects.
 
 
-   .. comethod:: monitor(id: str) -> AsyncIterator[bytes]
+   .. comethod:: monitor(id: str, *, \
+                         cluster_name: Optional[str] = None, \
+                 ) -> AsyncIterator[bytes]
       :async-for:
 
       Get job logs as a sequence of data chunks, e.g.::
@@ -194,11 +229,16 @@ Jobs
 
       :param str id: job :attr:`~JobDescription.id` to retrieve logs.
 
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
       :return: :class:`~collections.abc.AsyncIterator` over :class:`bytes` log chunks.
 
 
    .. comethod:: port_forward(id: str, local_port: int, job_port: int, *, \
-                              no_key_check: bool = False \
+                              no_key_check: bool = False, \
+                              cluster_name: Optional[str] = None \
                  ) -> None
       :async-with:
 
@@ -213,7 +253,14 @@ Jobs
 
       :param int jot_port: remote TCP port in a job to forward.
 
-   .. comethod:: resize(id: str, *, w: int, h: int) -> None
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
+
+   .. comethod:: resize(id: str, *, \
+                        w: int, h: int, \
+                        cluster_name: Optional[str] = None, \
+                 ) -> None
 
       Resize existing TTY job.
 
@@ -222,6 +269,10 @@ Jobs
       :param int w: New screen width.
 
       :param int h: New screen height.
+
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
 
    .. comethod:: run(container: Container, \
                      *, \
@@ -365,7 +416,9 @@ Jobs
 
       :return: :class:`JobDescription` instance with information about started job.
 
-   .. comethod:: send_signal(id: str, signal: Union[str, int]) -> None
+   .. comethod:: send_signal(id: str, signal: Union[str, int], *, \
+                             cluster_name: Optional[str] = None, \
+                 ) -> None
 
       Send signal to a job.
 
@@ -374,6 +427,10 @@ Jobs
       :param signal: The signal number or literal name, e.g. ``9`` or ``"SIGKILL"``. See
                      https://www.man7.org/linux/man-pages/man7/signal.7.html for more
                      details about signal types.
+
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
 
    .. comethod:: status(id: str) -> JobDescription
 
@@ -389,7 +446,9 @@ Jobs
 
       :return: :class:`List[str]` list of tags.
 
-   .. comethod:: top(id: str) -> AsyncIterator[JobTelemetry]
+   .. comethod:: top(id: str, *, \
+                     cluster_name: Optional[str] = None, \
+                 ) -> AsyncIterator[JobTelemetry]
       :async-for:
 
       Get job usage statistics, e.g.::
@@ -398,6 +457,10 @@ Jobs
               print(data.cpu, data.memory)
 
       :param str id: job :attr:`~JobDescription.id` to get telemetry data.
+
+      :param str cluster_name: cluster on which the job is running.
+
+                               ``None`` means the current cluster (default).
 
       :return: asynchronous iterator which emits `JobTelemetry` objects periodically.
 


### PR DESCRIPTION
All job related commands support now jobs on other clusters.

Commands `neuro exec`, `neuro port-forward`, `neuro logs` and `neuro job save` only support jobs on other clusters if they are specified by URI (jobs on the current cluster can be also specified by bare ID or name).
