### PR TITLE
Fix loop close errors

### DIFF
--- a/neuro-cli/src/neuro_cli/asyncio_utils.py
+++ b/neuro-cli/src/neuro_cli/asyncio_utils.py
@@ -7,7 +7,7 @@ import ssl
 import sys
 import threading
 import warnings
-from asyncio.events import AbstractEventLoop
+from asyncio import AbstractEventLoop
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, TypeVar

--- a/neuro-cli/src/neuro_cli/asyncio_utils.py
+++ b/neuro-cli/src/neuro_cli/asyncio_utils.py
@@ -7,6 +7,7 @@ import ssl
 import sys
 import threading
 import warnings
+from asyncio.events import AbstractEventLoop
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, TypeVar
@@ -30,6 +31,7 @@ class Runner:
         self._started = False
         self._stopped = False
         self._executor = ThreadPoolExecutor()
+        self._old_loop: Optional[AbstractEventLoop] = None
         self._loop = asyncio.new_event_loop()
         self._loop.set_default_executor(self._executor)
         _setup_exception_handler(self._loop, self._debug)
@@ -67,6 +69,7 @@ class Runner:
                 raise RuntimeError(
                     "asyncio.run() cannot be called from a running event loop"
                 )
+            self._old_loop = current_loop
 
         asyncio.set_event_loop(self._loop)
         self._loop.set_debug(self._debug)
@@ -82,7 +85,7 @@ class Runner:
             self._loop.run_until_complete(self._loop.shutdown_asyncgens())
         finally:
             self._executor.shutdown(wait=True)
-            asyncio.set_event_loop(None)
+            asyncio.set_event_loop(self._old_loop)
             # simple workaround for:
             # http://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
             with warnings.catch_warnings():


### PR DESCRIPTION
Current code sometimes triggers following tracebacks:
```
Exception ignored in: <function BaseEventLoop.__del__ at 0x101c69830>
Traceback (most recent call last):
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 628, in __del__
    self.close()
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/unix_events.py", line 54, in close
    super().close()
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/selector_events.py", line 91, in close
    self._close_self_pipe()
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/selector_events.py", line 98, in _close_self_pipe
    self._remove_reader(self._ssock.fileno())
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/selector_events.py", line 271, in _remove_reader
    key = self._selector.get_key(fd)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/selectors.py", line 190, in get_key
    return mapping[fileobj]
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/selectors.py", line 71, in __getitem__
    fd = self._selector._fileobj_lookup(fileobj)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/selectors.py", line 225, in _fileobj_lookup
    return _fileobj_to_fd(fileobj)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/selectors.py", line 42, in _fileobj_to_fd
    raise ValueError("Invalid file descriptor: {}".format(fd))
ValueError: Invalid file descriptor: -1
```
This is because call to `asyncio.get_event_loop()` at line 63 creates one more event loop (if it is the main thread) and it isn't closed properly because we do not restore it.
