### PR TITLE
Do not use user-provided roles for service accounts

### DIFF
--- a/CHANGELOG.D/2167.feature
+++ b/CHANGELOG.D/2167.feature
@@ -1,0 +1,2 @@
+Dropped `role` argument from `neuro service-account create`: platform automatically generates
+new role for service account without any permissions.

--- a/CLI.md
+++ b/CLI.md
@@ -2324,7 +2324,7 @@ Create a service account.
 **Usage:**
 
 ```bash
-neuro service-account create [OPTIONS] ROLE
+neuro service-account create [OPTIONS]
 ```
 
 **Options:**

--- a/neuro-cli/docs/service-account.md
+++ b/neuro-cli/docs/service-account.md
@@ -48,7 +48,7 @@ Create a service account
 #### Usage
 
 ```bash
-neuro service-account create [OPTIONS] ROLE
+neuro service-account create [OPTIONS]
 ```
 
 Create a service account.

--- a/neuro-cli/src/neuro_cli/formatters/service_accounts.py
+++ b/neuro-cli/src/neuro_cli/formatters/service_accounts.py
@@ -14,10 +14,6 @@ from neuro_sdk import ServiceAccount
 from neuro_cli.formatters.utils import DatetimeFormatter
 
 
-def _format_role_name(account: ServiceAccount) -> str:
-    return account.role + (" (deleted)" if account.role_deleted else "")
-
-
 class BaseServiceAccountsFormatter:
     @abc.abstractmethod
     def __call__(self, accounts: Sequence[ServiceAccount]) -> RenderableType:
@@ -40,7 +36,7 @@ class ServiceAccountsFormatter(BaseServiceAccountsFormatter):
         line = [
             account.id,
             account.name or "",
-            _format_role_name(account),
+            account.role,
             account.default_cluster,
             self._datetime_formatter(account.created_at),
         ]
@@ -75,7 +71,7 @@ class ServiceAccountFormatter:
         table.add_column(style="bold")
         table.add_row("Id", account.id)
         table.add_row("Name", account.name or "")
-        table.add_row("Role", _format_role_name(account))
+        table.add_row("Role", account.role)
         table.add_row("Owner", account.owner)
         table.add_row("Default cluster", account.default_cluster)
         table.add_row("Created at", self._datetime_formatter(account.created_at))

--- a/neuro-cli/src/neuro_cli/service_accounts.py
+++ b/neuro-cli/src/neuro_cli/service_accounts.py
@@ -45,7 +45,6 @@ async def ls(root: Root) -> None:
 
 
 @command()
-@argument("role", required=True)
 @option(
     "--name",
     metavar="NAME",
@@ -61,7 +60,6 @@ async def ls(root: Root) -> None:
 )
 async def create(
     root: Root,
-    role: str,
     name: Optional[str],
     default_cluster: Optional[str],
 ) -> None:
@@ -70,7 +68,6 @@ async def create(
     """
 
     account, token = await root.client.service_accounts.create(
-        role=role,
         name=name,
         default_cluster=default_cluster,
     )

--- a/neuro-cli/tests/unit/formatters/ascii/test_disks_formatter_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/test_disks_formatter_0.ref
@@ -1,6 +1,6 @@
-Id                                                     Name    Role                  Default cluster   Created At   
- ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
-  account-1                                              test1   test-role             cluster           Mar 04 2017  
-  account-2                                              test2   test-role (deleted)   cluster           Mar 04 2017  
-  account-3                                              test3   test-role             cluster           Mar 04 2017  
-  account-4                                              test4   test-role             cluster           Mar 04 2017
+Id                                                     Name    Role        Default cluster   Created At   
+ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
+  account-1                                              test1   test-role   cluster           Mar 04 2017  
+  account-2                                              test2   test-role   cluster           Mar 04 2017  
+  account-3                                              test3   test-role   cluster           Mar 04 2017  
+  account-4                                              test4   test-role   cluster           Mar 04 2017

--- a/neuro-cli/tests/unit/formatters/test_service_accounts.py
+++ b/neuro-cli/tests/unit/formatters/test_service_accounts.py
@@ -21,7 +21,6 @@ def test_service_account_formatter(rich_cmp: Any) -> None:
         owner="user",
         default_cluster="cluster",
         created_at=isoparse("2017-03-04T12:28:59.759433+00:00"),
-        role_deleted=False,
     )
     fmtr = ServiceAccountFormatter(datetime_formatter=format_datetime_human)
     rich_cmp(fmtr(account))
@@ -37,7 +36,6 @@ def service_accounts_list() -> List[ServiceAccount]:
             owner="user",
             default_cluster="cluster",
             created_at=isoparse("2017-03-04T12:28:59.759433+00:00"),
-            role_deleted=False,
         ),
         ServiceAccount(
             id="account-2",
@@ -46,7 +44,6 @@ def service_accounts_list() -> List[ServiceAccount]:
             owner="user",
             default_cluster="cluster",
             created_at=isoparse("2017-03-04T12:28:59.759433+00:00"),
-            role_deleted=True,
         ),
         ServiceAccount(
             id="account-3",
@@ -55,7 +52,6 @@ def service_accounts_list() -> List[ServiceAccount]:
             owner="user",
             default_cluster="cluster",
             created_at=isoparse("2017-03-04T12:28:59.759433+00:00"),
-            role_deleted=False,
         ),
         ServiceAccount(
             id="account-4",
@@ -64,7 +60,6 @@ def service_accounts_list() -> List[ServiceAccount]:
             owner="user",
             default_cluster="cluster",
             created_at=isoparse("2017-03-04T12:28:59.759433+00:00"),
-            role_deleted=False,
         ),
     ]
 

--- a/neuro-sdk/docs/service_accounts_reference.rst
+++ b/neuro-sdk/docs/service_accounts_reference.rst
@@ -20,17 +20,13 @@ ServiceAccounts
       List user's service accounts, async iterator. Yields :class:`ServiceAccount` instances.
 
    .. comethod:: create(  \
-                        role: str, \
                         name: typing.Optional[str], \
                         default_cluster: typing.Optional[str], \
                  ) -> typing.Tuple[ServiceAccount, str]
 
-      Create a service account based on role *role*.
+      Create a service account.
 
       :param str role: Authorization role to use for this service account.
-
-      :param ~typing.Optional[str] name: Optional name of the service account. Should be unique among all user's
-                                         service accounts.
 
       :param ~typing.Optional[str] default_cluster: Default cluster to embed into generated token. Defaults
                                                     to current cluster.

--- a/neuro-sdk/src/neuro_sdk/service_accounts.py
+++ b/neuro-sdk/src/neuro_sdk/service_accounts.py
@@ -20,7 +20,6 @@ class ServiceAccount:
     default_cluster: str
     role: str
     created_at: datetime
-    role_deleted: bool
 
 
 class ServiceAccounts(metaclass=NoPublicConstructor):
@@ -35,7 +34,6 @@ class ServiceAccounts(metaclass=NoPublicConstructor):
             name=payload["name"],
             default_cluster=payload["default_cluster"],
             role=payload["role"],
-            role_deleted=payload["role_deleted"],
             created_at=isoparse(payload["created_at"]),
         )
 
@@ -49,7 +47,6 @@ class ServiceAccounts(metaclass=NoPublicConstructor):
 
     async def create(
         self,
-        role: str,
         name: Optional[str] = None,
         default_cluster: Optional[str] = None,
     ) -> Tuple[ServiceAccount, str]:
@@ -57,7 +54,6 @@ class ServiceAccounts(metaclass=NoPublicConstructor):
         auth = await self._config._api_auth()
         data = {
             "name": name,
-            "role": role,
             "default_cluster": default_cluster or self._config.cluster_name,
         }
         async with self._core.request("POST", url, auth=auth, json=data) as resp:

--- a/neuro-sdk/tests/test_service_accounts.py
+++ b/neuro-sdk/tests/test_service_accounts.py
@@ -60,7 +60,6 @@ async def test_list(
             owner="user",
             default_cluster="cluster1",
             created_at=created_at,
-            role_deleted=False,
         ),
         ServiceAccount(
             id="account-2",
@@ -69,7 +68,6 @@ async def test_list(
             owner="user",
             default_cluster="cluster2",
             created_at=created_at,
-            role_deleted=True,
         ),
     ]
 
@@ -85,7 +83,6 @@ async def test_add(
         data = await request.json()
         assert data == {
             "name": "test-account",
-            "role": "test-role",
             "default_cluster": "cluster",
         }
         return web.json_response(
@@ -108,7 +105,7 @@ async def test_add(
 
     async with make_client(srv.make_url("/")) as client:
         account, token = await client.service_accounts.create(
-            name="test-account", role="test-role", default_cluster="cluster"
+            name="test-account", default_cluster="cluster"
         )
         assert account == ServiceAccount(
             id="account-1",
@@ -117,7 +114,6 @@ async def test_add(
             owner="user",
             default_cluster="cluster",
             created_at=created_at,
-            role_deleted=False,
         )
         assert token == "fake-token"
 
@@ -157,7 +153,6 @@ async def test_get(
             owner="user",
             default_cluster="cluster",
             created_at=created_at,
-            role_deleted=False,
         )
 
 


### PR DESCRIPTION
Checklist before merging it:

- [x] Deploy [service-account service](https://github.com/neuro-inc/platform-service-accounts-api) to staging
- [x] Deploy new version of platform-auth to staging
- [x] Deploy new version of platform-disks-api to staging
- [x] Deploy new version of platform-secrets-api to staging
- [x] Merge this fix https://github.com/neuro-inc/platform-api/pull/1614 and deploy it to staging
