### PR TITLE
Support Python 3.10

### DIFF
--- a/neuro-cli/src/neuro_cli/asyncio_utils.py
+++ b/neuro-cli/src/neuro_cli/asyncio_utils.py
@@ -59,15 +59,16 @@ class Runner:
         assert not self._stopped
         self._started = True
 
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # there is no current loop
-            pass
-        else:
-            raise RuntimeError(
-                "asyncio.run() cannot be called from a running event loop"
-            )
+        if sys.version_info >= (3, 7):
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # there is no current loop
+                pass
+            else:
+                raise RuntimeError(
+                    "asyncio.run() cannot be called from a running event loop"
+                )
         try:
             current_loop = asyncio.get_event_loop_policy().get_event_loop()
         except RuntimeError:

--- a/neuro-cli/src/neuro_cli/formatters/storage.py
+++ b/neuro-cli/src/neuro_cli/formatters/storage.py
@@ -520,11 +520,12 @@ class FilesSorter(str, enum.Enum):
 
     def key(self) -> Any:
         field = None
-        if self == self.NAME:
+        cls = type(self)
+        if self == cls.NAME:
             field = "name"
-        elif self == self.SIZE:
+        elif self == cls.SIZE:
             field = "size"
-        elif self == self.TIME:
+        elif self == cls.TIME:
             field = "modification_time"
         assert field
         return operator.attrgetter(field)

--- a/neuro-cli/tests/unit/test_config.py
+++ b/neuro-cli/tests/unit/test_config.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 from decimal import Decimal
 from pathlib import Path
@@ -75,7 +74,7 @@ def test_prompt_cluster(make_client: Callable[..., Client]) -> None:
     root._client = root.run(_async_make_client())
 
     session = mock.Mock()
-    loop = asyncio.get_event_loop()
+    loop = root._runner._loop
     fut = loop.create_future()
     fut.set_result("second")
     session.prompt_async.return_value = fut
@@ -145,7 +144,7 @@ def test_prompt_cluster_default(make_client: Callable[..., Client]) -> None:
     root._client = root.run(_async_make_client())
 
     session = mock.Mock()
-    loop = asyncio.get_event_loop()
+    loop = root._runner._loop
     fut = loop.create_future()
     fut.set_result("")
     session.prompt_async.return_value = fut

--- a/neuro-sdk/src/neuro_sdk/config_factory.py
+++ b/neuro-sdk/src/neuro_sdk/config_factory.py
@@ -41,7 +41,7 @@ async def __make_session(
 ) -> aiohttp.ClientSession:
     from . import __version__
 
-    ssl_context = ssl.SSLContext()
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     ssl_context.load_verify_locations(capath=certifi.where())
     connector = aiohttp.TCPConnector(ssl=ssl_context)
     return aiohttp.ClientSession(

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -98,15 +98,17 @@ class JobStatus(str, enum.Enum):
 
     @property
     def is_pending(self) -> bool:
-        return self in (self.PENDING, self.SUSPENDED)
+        cls = type(self)
+        return self in (cls.PENDING, cls.SUSPENDED)
 
     @property
     def is_running(self) -> bool:
-        return self == self.RUNNING
+        return self == type(self).RUNNING
 
     @property
     def is_finished(self) -> bool:
-        return self in (self.SUCCEEDED, self.FAILED, self.CANCELLED)
+        cls = type(self)
+        return self in (cls.SUCCEEDED, cls.FAILED, cls.CANCELLED)
 
     @classmethod
     def items(cls) -> Set["JobStatus"]:
@@ -119,6 +121,9 @@ class JobStatus(str, enum.Enum):
     @classmethod
     def finished_items(cls) -> Set["JobStatus"]:
         return {item for item in cls.items() if item.is_finished}
+
+    __format__ = str.__format__
+    __str__ = str.__str__
 
 
 @dataclass(frozen=True)

--- a/neuro-sdk/tests/test_core.py
+++ b/neuro-sdk/tests/test_core.py
@@ -34,7 +34,7 @@ _ApiFactory = Callable[[URL], AsyncContextManager[_Core]]
 async def api_factory() -> AsyncIterator[_ApiFactory]:
     @asynccontextmanager
     async def factory(url: URL) -> AsyncIterator[_Core]:
-        ssl_context = ssl.SSLContext()
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         ssl_context.load_verify_locations(capath=certifi.where())
         connector = aiohttp.TCPConnector(ssl=ssl_context)
         session = aiohttp.ClientSession(connector=connector)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ markers =
   e2e_job
   require_admin
 filterwarnings=error
+  ignore:.*PROTOCOL_TLS is deprecated:DeprecationWarning:neuro_sdk
+  ignore:.*PROTOCOL_TLS is deprecated:DeprecationWarning:tests
+  ignore:.*PROTOCOL_TLS is deprecated:DeprecationWarning:aiohttp
   ; ignore::DeprecationWarning:yaml
   ignore:returning HTTPException object is deprecated.+:DeprecationWarning:aiodocker
   ignore:ssl_context is deprecated.+:DeprecationWarning:aiodocker


### PR DESCRIPTION
Solved issues:
* `asyncio.get_event_loop()` outside of running loop is deprecated.
* `asyncio.gather()` does not support the `loop` argument.
* Access to Enum members via instance attributes is deprecated.
* `ssl.SSLContext()` requires protocol argument.
* Enum formatting emits deprecation warning by default. Its behavior will change in future.

Unsolved issues:
* `ssl.PROTOCOL_TLS` is deprecated but recommended `ssl.PROTOCOL_TLS_CLIENT` and `ssl.PROTOCOL_TLS_SERVER` do not work. The warning has been silenced.
* Deprecated `ssl.PROTOCOL_TLS` is also implicitly used in `aiohttp`.
