### PR TITLE
Make all asynchronous generators in public API context managers

### DIFF
--- a/CHANGELOG.D/2192.feature
+++ b/CHANGELOG.D/2192.feature
@@ -1,0 +1,5 @@
+All asynchronous iterators returned by API support now an asynchronous manager protocol. It is strongly preferable to use "asyn with" before iterating them. For example::
+
+          async with client.jobs.list() as jobs:
+              async for job in jobs:
+                  print(job.id)

--- a/neuro-cli/src/neuro_cli/ael.py
+++ b/neuro-cli/src/neuro_cli/ael.py
@@ -24,7 +24,6 @@ from prompt_toolkit.shortcuts import PromptSession
 from typing_extensions import NoReturn
 
 from neuro_sdk import IllegalArgumentError, JobDescription, JobStatus, StdStream
-from neuro_sdk.utils import aclosing
 
 from .const import EX_IOERR, EX_PLATFORMERROR
 from .formatters.jobs import ExecStopProgress, JobStopProgress
@@ -80,7 +79,7 @@ async def process_logs(
 ) -> None:
     codec_info = codecs.lookup("utf8")
     decoder = codec_info.incrementaldecoder("replace")
-    async with aclosing(root.client.jobs.monitor(job, cluster_name=cluster_name)) as it:
+    async with root.client.jobs.monitor(job, cluster_name=cluster_name) as it:
         async for chunk in it:
             if not chunk:
                 txt = decoder.decode(b"", final=True)

--- a/neuro-cli/src/neuro_cli/blob_storage.py
+++ b/neuro-cli/src/neuro_cli/blob_storage.py
@@ -18,7 +18,6 @@ from neuro_sdk import (
 )
 from neuro_sdk.file_filter import FileFilter
 from neuro_sdk.url_utils import _extract_path
-from neuro_sdk.utils import aclosing
 
 from .const import EX_OSFILE
 from .formatters.blob_storage import (
@@ -151,7 +150,7 @@ async def glob(root: Root, patterns: Sequence[str]) -> None:
             uri_text = painter.paint(str(short_uri), FileStatusType.FILE)
             root.print(Text.assemble("Using pattern ", uri_text, ":"))
 
-        async with aclosing(blob_storage.glob_blobs(bucket_name, pattern)) as blob_iter:
+        async with blob_storage.glob_blobs(bucket_name, pattern) as blob_iter:
             async for blob in blob_iter:
                 root.print(blob.uri)
 
@@ -408,10 +407,8 @@ async def _expand(
                         "You can not glob on bucket names. Please provide name "
                         "explicitly."
                     )
-                async with aclosing(
-                    root.client.blob_storage.glob_blobs(
-                        bucket_name=bucket_name, pattern=key
-                    )
+                async with root.client.blob_storage.glob_blobs(
+                    bucket_name=bucket_name, pattern=key
                 ) as blob_iter:
                     async for blob in blob_iter:
                         uris.append(blob.uri)

--- a/neuro-cli/src/neuro_cli/click_types.py
+++ b/neuro-cli/src/neuro_cli/click_types.py
@@ -8,7 +8,6 @@ import click
 from click import BadParameter
 
 from neuro_sdk import LocalImage, RemoteImage, TagOption
-from neuro_sdk.utils import aclosing
 
 from .parse_utils import (
     JobTableFormat,
@@ -276,10 +275,8 @@ class JobType(AsyncType[str]):
             ret: List[Tuple[str, Optional[str]]] = []
             now = datetime.now()
             limit = int(os.environ.get(JOB_LIMIT_ENV, 100))
-            async with aclosing(
-                client.jobs.list(
-                    since=now - timedelta(days=7), reverse=True, limit=limit
-                )
+            async with client.jobs.list(
+                since=now - timedelta(days=7), reverse=True, limit=limit
             ) as it:
                 async for job in it:
                     job_name = job.name or ""
@@ -316,7 +313,7 @@ class DiskType(AsyncType[str]):
     ) -> List[Tuple[str, Optional[str]]]:
         async with await root.init_client() as client:
             ret: List[Tuple[str, Optional[str]]] = []
-            async with aclosing(client.disks.list()) as it:
+            async with client.disks.list() as it:
                 async for disk in it:
                     disk_name = disk.name or ""
                     for test in (
@@ -349,7 +346,7 @@ class ServiceAccountType(AsyncType[str]):
     ) -> List[Tuple[str, Optional[str]]]:
         async with await root.init_client() as client:
             ret: List[Tuple[str, Optional[str]]] = []
-            async with aclosing(client.service_accounts.list()) as it:
+            async with client.service_accounts.list() as it:
                 async for account in it:
                     account_name = account.name or ""
                     for test in (

--- a/neuro-cli/src/neuro_cli/disks.py
+++ b/neuro-cli/src/neuro_cli/disks.py
@@ -1,8 +1,6 @@
 from datetime import timedelta
 from typing import Optional, Sequence
 
-from neuro_sdk.utils import aclosing
-
 from neuro_cli.click_types import DISK, DISK_NAME
 from neuro_cli.formatters.utils import get_datetime_formatter
 from neuro_cli.utils import resolve_disk
@@ -52,7 +50,7 @@ async def ls(root: Root, full_uri: bool, long_format: bool) -> None:
 
     disks = []
     with root.status("Fetching disks") as status:
-        async with aclosing(root.client.disks.list()) as it:
+        async with root.client.disks.list() as it:
             async for disk in it:
                 disks.append(disk)
                 status.update(f"Fetching disks ({len(disks)} loaded)")

--- a/neuro-cli/src/neuro_cli/job.py
+++ b/neuro-cli/src/neuro_cli/job.py
@@ -28,7 +28,6 @@ from neuro_sdk import (
     RemoteImage,
     Volume,
 )
-from neuro_sdk.utils import aclosing
 
 from neuro_cli.formatters.images import DockerImageProgress
 from neuro_cli.formatters.utils import (
@@ -426,19 +425,16 @@ async def ls(
             datetime_formatter=get_datetime_formatter(root.iso_datetime_format),
         )
 
-    async with aclosing(
-        root.client.jobs.list(
-            statuses=statuses,
-            name=name,
-            owners=owners,
-            tags=tags,
-            since=_parse_date(since),
-            until=_parse_date(until),
-            reverse=recent_first,
-            cluster_name=cluster,
-        )
+    async with root.client.jobs.list(
+        statuses=statuses,
+        name=name,
+        owners=owners,
+        tags=tags,
+        since=_parse_date(since),
+        until=_parse_date(until),
+        reverse=recent_first,
+        cluster_name=cluster,
     ) as jobs:
-
         # client-side filtering
         if description:
             jobs = (job async for job in jobs if job.description == description)
@@ -703,18 +699,15 @@ async def top(
         async def create_pollers() -> None:
             nonlocal since_dt
             while True:
-                async with aclosing(
-                    root.client.jobs.list(
-                        statuses=JobStatus.active_items(),
-                        name=name,
-                        owners=owners,
-                        tags=tags,
-                        since=since_dt,
-                        until=until_dt,
-                        cluster_name=cluster,
-                    )
+                async with root.client.jobs.list(
+                    statuses=JobStatus.active_items(),
+                    name=name,
+                    owners=owners,
+                    tags=tags,
+                    since=since_dt,
+                    until=until_dt,
+                    cluster_name=cluster,
                 ) as jobs:
-
                     # client-side filtering
                     if description:
                         jobs = (
@@ -738,8 +731,8 @@ async def top(
 
     async def poller(job: JobDescription) -> None:
         try:
-            async with aclosing(
-                root.client.jobs.top(job.id, cluster_name=job.cluster_name)
+            async with root.client.jobs.top(
+                job.id, cluster_name=job.cluster_name
             ) as it:
                 async for info in it:
                     formatter.update(job, info)

--- a/neuro-cli/src/neuro_cli/secrets.py
+++ b/neuro-cli/src/neuro_cli/secrets.py
@@ -1,7 +1,5 @@
 import pathlib
 
-from neuro_sdk.utils import aclosing
-
 from neuro_cli.formatters.secrets import (
     BaseSecretsFormatter,
     SecretsFormatter,
@@ -41,7 +39,7 @@ async def ls(root: Root, full_uri: bool) -> None:
 
     secrets = []
     with root.status("Fetching secrets") as status:
-        async with aclosing(root.client.secrets.list()) as it:
+        async with root.client.secrets.list() as it:
             async for secret in it:
                 secrets.append(secret)
                 status.update(f"Fetching secrets ({len(secrets)} loaded)")

--- a/neuro-cli/src/neuro_cli/service_accounts.py
+++ b/neuro-cli/src/neuro_cli/service_accounts.py
@@ -1,7 +1,5 @@
 from typing import Optional, Sequence
 
-from neuro_sdk.utils import aclosing
-
 from neuro_cli.click_types import SERVICE_ACCOUNT
 from neuro_cli.formatters.service_accounts import (
     BaseServiceAccountsFormatter,
@@ -38,7 +36,7 @@ async def ls(root: Root) -> None:
 
     accounts = []
     with root.status("Fetching service accounts") as status:
-        async with aclosing(root.client.service_accounts.list()) as it:
+        async with root.client.service_accounts.list() as it:
             async for account in it:
                 accounts.append(account)
                 status.update(f"Fetching service accounts ({len(accounts)} loaded)")

--- a/neuro-cli/src/neuro_cli/storage.py
+++ b/neuro-cli/src/neuro_cli/storage.py
@@ -12,7 +12,6 @@ from yarl import URL
 from neuro_sdk import Client, FileStatusType, IllegalArgumentError, ResourceNotFound
 from neuro_sdk.file_filter import FileFilter
 from neuro_sdk.url_utils import _extract_path
-from neuro_sdk.utils import aclosing
 
 from .const import EX_OSFILE
 from .formatters.storage import (
@@ -159,7 +158,7 @@ async def ls(
                     uri_text = painter.paint(str(uri), FileStatusType.DIRECTORY)
                     root.print(Text.assemble("List of ", uri_text, ":"))
 
-                async with aclosing(root.client.storage.ls(uri)) as it:
+                async with root.client.storage.ls(uri) as it:
                     files = [file async for file in it]
                 files.sort(key=FilesSorter(sort).key())
         except (OSError, ResourceNotFound, IllegalArgumentError) as error:
@@ -199,7 +198,7 @@ async def glob(root: Root, patterns: Sequence[str]) -> None:
             painter = get_painter(root.color)
             uri_text = painter.paint(str(uri), FileStatusType.FILE)
             root.print(Text.assemble("Using pattern ", uri_text, ":"))
-        async with aclosing(root.client.storage.glob(uri)) as it:
+        async with root.client.storage.glob(uri) as it:
             async for file in it:
                 root.print(file)
 
@@ -690,7 +689,7 @@ async def _expand(
         uri_path = str(_extract_path(uri))
         if glob and globmodule.has_magic(uri_path):
             if uri.scheme == "storage":
-                async with aclosing(root.client.storage.glob(uri)) as it:
+                async with root.client.storage.glob(uri) as it:
                     async for file in it:
                         uris.append(file)
             elif allow_file and path.startswith("file:"):
@@ -761,7 +760,7 @@ async def fetch_tree(client: Client, uri: URL, show_all: bool) -> Tree:
     files = []
     tasks = []
     size = 0
-    async with aclosing(client.storage.ls(uri)) as it:
+    async with client.storage.ls(uri) as it:
         async for item in it:
             if not show_all and item.name.startswith("."):
                 continue

--- a/neuro-cli/src/neuro_cli/utils.py
+++ b/neuro-cli/src/neuro_cli/utils.py
@@ -34,7 +34,6 @@ from yarl import URL
 
 from neuro_sdk import Action, Client, JobStatus, Volume
 from neuro_sdk.url_utils import uri_from_cli
-from neuro_sdk.utils import aclosing
 
 from .parse_utils import parse_timedelta
 from .root import Root
@@ -461,14 +460,12 @@ async def resolve_job_ex(
         return id_or_name, cluster_name
 
     try:
-        async with aclosing(
-            client.jobs.list(
-                name=id_or_name,
-                owners={owner},
-                reverse=True,
-                limit=1,
-                cluster_name=cluster_name,
-            )
+        async with client.jobs.list(
+            name=id_or_name,
+            owners={owner},
+            reverse=True,
+            limit=1,
+            cluster_name=cluster_name,
         ) as it:
             async for job in it:
                 log.debug(f"Job name '{id_or_name}' resolved to job ID '{job.id}'")

--- a/neuro-sdk/docs/blob_storage_reference.rst
+++ b/neuro-sdk/docs/blob_storage_reference.rst
@@ -116,14 +116,16 @@ Blob Storage
       :raises: :exc:`FileNotFound` if key does not exist *or* you don't have access
           to it.
 
-   .. comethod:: fetch_blob(bucket_name: str, key: str, offset: int = 0, size: Optional[int] = None) -> AsyncIterator[bytes]
+   .. comethod:: fetch_blob(bucket_name: str, key: str, offset: int = 0, size: Optional[int] = None) -> AsyncContextManager[AsyncIterator[bytes]]
+      :async-with:
       :async-for:
 
       Look up the blob and return it's body content only. The content will be streamed
       using an asynchronous iterator, e.g.::
 
-         async for data in client.blob_storage.fetch_blob("my_bucket", key: "file.txt"):
-             print("Next chunk of data:", data)
+         async with client.blob_storage.fetch_blob("my_bucket", key="file.txt") as content:
+             async for data in content:
+                 print("Next chunk of data:", data)
 
       :param str bucket_name: Name of the bucket.
       :param str key: Key of the blob.

--- a/neuro-sdk/docs/disks_reference.rst
+++ b/neuro-sdk/docs/disks_reference.rst
@@ -13,7 +13,7 @@ Disks
 
    Persistent disks subsystems. Disks can be passed as mounted volumes into a running job.
 
-   .. comethod:: list() -> AsyncIterator[Disk]
+   .. comethod:: list() -> AsyncContextManager[AsyncIterator[Disk]]
       :async-for:
 
       List user's disks, async iterator. Yields :class:`Disk` instances.

--- a/neuro-sdk/docs/functions_reference.rst
+++ b/neuro-sdk/docs/functions_reference.rst
@@ -24,8 +24,9 @@ API functions
    The usage is::
 
       async with neuro_sdk.get() as client:
-          async for job in client.jobs.list():
-              print(job.id)
+          async with client.jobs.list() as jobs:
+              async for job in jobs:
+                  print(job.id)
 
    See :meth:`Factory.get` for optional function arguments meaning.
 

--- a/neuro-sdk/docs/index.rst
+++ b/neuro-sdk/docs/index.rst
@@ -35,7 +35,8 @@ configuration file::
   import neuro_sdk
 
   async with neuro_sdk.get() as client:
-      jobs = [job async for job in client.jobs.list()]
+      async with client.jobs.list() as job_iter:
+          jobs = [job async for job in job_iter]
 
 
 The example above instantiates a ``client`` object in *async context manager* and

--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -144,7 +144,8 @@ Jobs
                       reverse: bool = False, \
                       limit: Optional[int] = None, \
                       cluster_name: Optional[str] = None, \
-                 ) -> AsyncIterator[JobDescription]
+                 ) -> AsyncContextManager[AsyncIterator[JobDescription]]
+      :async-with:
       :async-for:
 
       List user jobs, all scheduled, running and finished jobs by default.
@@ -219,13 +220,15 @@ Jobs
 
    .. comethod:: monitor(id: str, *, \
                          cluster_name: Optional[str] = None, \
-                 ) -> AsyncIterator[bytes]
+                 ) -> AsyncContextManager[AsyncIterator[bytes]]
+      :async-with:
       :async-for:
 
       Get job logs as a sequence of data chunks, e.g.::
 
-         async for chunk in client.jobs.monitor(job_id):
-             print(chunk.encode('utf8', errors='replace')
+         async with client.jobs.monitor(job_id) as it:
+             async for chunk in it:
+                 print(chunk.encode('utf8', errors='replace')
 
       :param str id: job :attr:`~JobDescription.id` to retrieve logs.
 
@@ -448,13 +451,15 @@ Jobs
 
    .. comethod:: top(id: str, *, \
                      cluster_name: Optional[str] = None, \
-                 ) -> AsyncIterator[JobTelemetry]
+                 ) -> AsyncContextManager[AsyncIterator[JobTelemetry]]
+      :async-with:
       :async-for:
 
       Get job usage statistics, e.g.::
 
-          async for data in client.jobs.top(job_id):
-              print(data.cpu, data.memory)
+          async with client.jobs.top(job_id) as top:
+              async for data in top:
+                  print(data.cpu, data.memory)
 
       :param str id: job :attr:`~JobDescription.id` to get telemetry data.
 

--- a/neuro-sdk/docs/secrets_reference.rst
+++ b/neuro-sdk/docs/secrets_reference.rst
@@ -14,7 +14,8 @@ Secrets
    Secured secrets subsystems.  Secrets can be passed as mounted files and environment
    variables into a running job.
 
-   .. comethod:: list() -> AsyncIterator[Secret]
+   .. comethod:: list() -> AsyncContextManager[AsyncIterator[Secret]]
+      :async-with:
       :async-for:
 
       List user's secrets, async iterator. Yields :class:`Secret` instances.

--- a/neuro-sdk/docs/service_accounts_reference.rst
+++ b/neuro-sdk/docs/service_accounts_reference.rst
@@ -14,7 +14,8 @@ ServiceAccounts
    Service accounts subsystems. Service accounts can be used to generate tokens that can be
    used in automated environments by third-party services.
 
-   .. comethod:: list() -> AsyncIterator[ServiceAccount]
+   .. comethod:: list() -> AsyncContextManager[AsyncIterator[ServiceAccount]]
+      :async-with:
       :async-for:
 
       List user's service accounts, async iterator. Yields :class:`ServiceAccount` instances.

--- a/neuro-sdk/docs/storage_reference.rst
+++ b/neuro-sdk/docs/storage_reference.rst
@@ -22,22 +22,25 @@ Storage
 
    .. rubric:: Remote filesystem operations
 
-   .. comethod:: glob(uri: URL, *, dironly: bool = False) -> AsyncIterator[URL]
+   .. comethod:: glob(uri: URL, *, dironly: bool = False) -> AsyncContextManager[AsyncIterator[URL]]
+      :async-with:
       :async-for:
 
       Glob the given relative pattern *uri* in the directory represented by this *uri*,
       yielding all matching remote files (of any kind)::
 
           folder = yarl.URL("storage:folder/*")
-          async for url in client.storage.glob(folder):
-              print(url)
+          async with client.storage.glob(folder) as uris:
+              async for uri in uris:
+                  print(uri)
 
       The ``“**”`` pattern means “this directory and all sub-directories,
       recursively”. In other words, it enables recursive globbing::
 
           folder = yarl.URL("storage:folder/**/*.py")
-          async for url in client.storage.glob(folder):
-              print(url)
+          async with client.storage.glob(folder) as uris:
+              async for uri in uris:
+                  print(uri)
 
       :param ~yarl.URL uri: a pattern to glob.
 
@@ -46,14 +49,16 @@ Storage
       :return: asynchronous iterator that can be used for enumerating found files and
                directories.
 
-   .. comethod:: ls(uri: URL) -> AsyncIterator[FileStatus]
+   .. comethod:: ls(uri: URL) -> AsyncContextManager[AsyncIterator[FileStatus]]
+      :async-with:
       :async-for:
 
       List a directory *uri* on the storage, e.g.::
 
          folder = yarl.URL("storage:folder")
-         async for status in client.storage.ls(folder):
-             print(status.name, status.size)
+         async with client.storage.ls(folder) as statuses:
+             async for status in statuses:
+                 print(status.name, status.size)
 
       :param ~yarl.URL uri: directory to list
 
@@ -130,7 +135,9 @@ Storage
                  yield str(i) * 10
 
          file = yarl.URL("storage:folder/file.bin")
-         await client.storage.create(file, gen())
+         source = gen()
+         await client.storage.create(file, source)
+         await source.aclose()
 
       :param ~yarl.URL uri: path to created file,
                             e.g. ``yarl.URL("storage:folder/file.txt")``.
@@ -149,14 +156,16 @@ Storage
 
       :param int offset: position in file from which to write.
 
-   .. comethod:: open(uri: URL, offset: int = 0, size: Optional[int] = None) -> AsyncIterator[bytes]
+   .. comethod:: open(uri: URL, offset: int = 0, size: Optional[int] = None) -> AsyncContextManager[AsyncIterator[bytes]]
+      :async-with:
       :async-for:
 
       Get the content of remote file *uri* or its fragment as asynchronous iterator, e.g.::
 
          file = yarl.URL("storage:folder/file.txt")
-         async for data in client.storage.open(file):
-             print(data)
+         async with client.storage.open(file) as content:
+             async for data in content:
+                 print(data)
 
       :param ~yarl.URL uri: storage path of remote file, e.g.
                             ``yarl.URL("storage:folder/file.txt")``.

--- a/neuro-sdk/src/neuro_sdk/core.py
+++ b/neuro-sdk/src/neuro_sdk/core.py
@@ -23,6 +23,7 @@ from .errors import (
     ServerNotAvailable,
 )
 from .tracing import gen_trace_id
+from .utils import asyncgeneratorcontextmanager
 
 if sys.version_info >= (3, 7):  # pragma: no cover
     from contextlib import asynccontextmanager
@@ -167,6 +168,7 @@ class _Core:
             else:
                 yield resp
 
+    @asyncgeneratorcontextmanager
     async def ws_connect(
         self, abs_url: URL, auth: str, *, headers: Optional[Dict[str, str]] = None
     ) -> AsyncIterator[WSMessage]:

--- a/neuro-sdk/src/neuro_sdk/disks.py
+++ b/neuro-sdk/src/neuro_sdk/disks.py
@@ -9,7 +9,7 @@ from yarl import URL
 
 from .config import Config
 from .core import _Core
-from .utils import NoPublicConstructor
+from .utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,7 @@ class Disks(metaclass=NoPublicConstructor):
             timeout_unused=timeout_unused,
         )
 
+    @asyncgeneratorcontextmanager
     async def list(self) -> AsyncIterator[Disk]:
         url = self._config.disk_api_url
         auth = await self._config._api_auth()

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -51,7 +51,7 @@ from .url_utils import (
     normalize_secret_uri,
     normalize_storage_path_uri,
 )
-from .utils import NoPublicConstructor, aclosing
+from .utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
 if sys.version_info >= (3, 7):  # pragma: no cover
     from contextlib import asynccontextmanager
@@ -391,6 +391,7 @@ class Jobs(metaclass=NoPublicConstructor):
             res = await resp.json()
             return _job_description_from_api(res, self._parse)
 
+    @asyncgeneratorcontextmanager
     async def list(
         self,
         *,
@@ -463,6 +464,7 @@ class Jobs(metaclass=NoPublicConstructor):
             # an error is raised for status >= 400
             return None  # 201 status code
 
+    @asyncgeneratorcontextmanager
     async def monitor(
         self, id: str, *, cluster_name: Optional[str] = None
     ) -> AsyncIterator[bytes]:
@@ -493,6 +495,7 @@ class Jobs(metaclass=NoPublicConstructor):
             ret = await resp.json()
             return ret["tags"]
 
+    @asyncgeneratorcontextmanager
     async def top(
         self, id: str, *, cluster_name: Optional[str] = None
     ) -> AsyncIterator[JobTelemetry]:
@@ -500,7 +503,7 @@ class Jobs(metaclass=NoPublicConstructor):
         auth = await self._config._api_auth()
         try:
             received_any = False
-            async with aclosing(self._core.ws_connect(url, auth=auth)) as ws:
+            async with self._core.ws_connect(url, auth=auth) as ws:
                 async for resp in ws:
                     yield _job_telemetry_from_api(resp.json())
                     received_any = True

--- a/neuro-sdk/src/neuro_sdk/secrets.py
+++ b/neuro-sdk/src/neuro_sdk/secrets.py
@@ -6,7 +6,7 @@ from yarl import URL
 
 from .config import Config
 from .core import _Core
-from .utils import NoPublicConstructor
+from .utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
 
 @dataclass(frozen=True)
@@ -25,6 +25,7 @@ class Secrets(metaclass=NoPublicConstructor):
         self._core = core
         self._config = config
 
+    @asyncgeneratorcontextmanager
     async def list(self) -> AsyncIterator[Secret]:
         url = self._config.secrets_url
         auth = await self._config._api_auth()

--- a/neuro-sdk/src/neuro_sdk/service_accounts.py
+++ b/neuro-sdk/src/neuro_sdk/service_accounts.py
@@ -7,7 +7,7 @@ from dateutil.parser import isoparse
 
 from .config import Config
 from .core import _Core
-from .utils import NoPublicConstructor
+from .utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class ServiceAccounts(metaclass=NoPublicConstructor):
             created_at=isoparse(payload["created_at"]),
         )
 
+    @asyncgeneratorcontextmanager
     async def list(self) -> AsyncIterator[ServiceAccount]:
         url = self._config.service_accounts_url
         auth = await self._config._api_auth()

--- a/neuro-sdk/src/neuro_sdk/utils.py
+++ b/neuro-sdk/src/neuro_sdk/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import sys
 from functools import partial
@@ -6,6 +7,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import (
     Any,
+    AsyncIterator,
     Awaitable,
     Callable,
     Coroutine,
@@ -23,6 +25,8 @@ import aiohttp
 from .errors import ConfigError
 
 _T = TypeVar("_T")
+_T_co = TypeVar("_T_co", covariant=True)
+_T_contra = TypeVar("_T_contra", contravariant=True)
 
 
 if sys.version_info >= (3, 7):
@@ -60,6 +64,52 @@ else:
             tb: Optional[TracebackType],
         ) -> None:
             await self.thing.aclose()  # type: ignore
+
+
+# TODO (S Storchaka 2021-06-01): Methods __aiter__ and __anext__
+# are supported for compatibility, but using the iterator without
+# "async with" is strongly discouraged. In future these methods
+# will be deprecated and finally removed. It will be just a context
+# manager returning an iterator.
+class _AsyncIteratorAndContextManager(
+    Generic[_T_co],
+    AsyncIterator[_T_co],
+    AsyncContextManager[AsyncIterator[_T_co]],
+):
+    def __init__(self, gen: AsyncIterator[_T_co]) -> None:
+        self._gen = gen
+
+    async def __aenter__(self) -> AsyncIterator[_T_co]:
+        return self._gen
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        # Actually it is an AsyncGenerator.
+        await self._gen.aclose()  # type: ignore
+
+    def __aiter__(self) -> AsyncIterator[_T_co]:
+        return self._gen.__aiter__()
+
+    def __anext__(self) -> Awaitable[_T_co]:
+        return self._gen.__anext__()
+
+
+# XXX (S Storchaka 2021-06-01): The decorated function should actually
+# return an AsyncGenerator, but all of our generator functions are annotated
+# as returning an AsyncIterator.
+def asyncgeneratorcontextmanager(
+    func: Callable[..., AsyncIterator[_T_co]]
+) -> Callable[..., _AsyncIteratorAndContextManager[_T_co]]:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> _AsyncIteratorAndContextManager[_T_co]:
+        gen = func(*args, **kwargs)
+        return _AsyncIteratorAndContextManager[_T_co](gen)
+
+    return wrapper
 
 
 class NoPublicConstructor(type):

--- a/neuro-sdk/tests/test_disks.py
+++ b/neuro-sdk/tests/test_disks.py
@@ -50,8 +50,9 @@ async def test_list(
     ret = []
 
     async with make_client(srv.make_url("/")) as client:
-        async for s in client.disks.list():
-            ret.append(s)
+        async with client.disks.list() as it:
+            async for s in it:
+                ret.append(s)
 
     assert ret == [
         Disk(

--- a/neuro-sdk/tests/test_secrets.py
+++ b/neuro-sdk/tests/test_secrets.py
@@ -26,8 +26,9 @@ async def test_list(
     ret = []
 
     async with make_client(srv.make_url("/")) as client:
-        async for s in client.secrets.list():
-            ret.append(s)
+        async with client.secrets.list() as it:
+            async for s in it:
+                ret.append(s)
 
     assert ret == [
         Secret(key="name1", owner="test", cluster_name="default"),

--- a/neuro-sdk/tests/test_service_accounts.py
+++ b/neuro-sdk/tests/test_service_accounts.py
@@ -49,8 +49,9 @@ async def test_list(
     ret = []
 
     async with make_client(srv.make_url("/")) as client:
-        async for s in client.service_accounts.list():
-            ret.append(s)
+        async with client.service_accounts.list() as it:
+            async for s in it:
+                ret.append(s)
 
     assert ret == [
         ServiceAccount(


### PR DESCRIPTION
* Add a decorator which converts a asynchronous generator function into
  a function returning a hybrid of context manager and iterator and
  decorate all public asynchronous generator functions which own resources.
* Document more preferable use of generators in examples.
* Properly close asynchronous generators in tests.