### PR TITLE
Add additional fields to JobDescription

### DIFF
--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -144,9 +144,6 @@ Jobs
                       reverse: bool = False, \
                       limit: Optional[int] = None, \
                       cluster_name: Optional[str] = None, \
-                      materialized: Optional[bool] = None, \
-                      being_dropped: Optional[bool] = False, \
-                      logs_removed: Optional[bool] = False, \
                  ) -> AsyncContextManager[AsyncIterator[JobDescription]]
       :async-with:
       :async-for:
@@ -217,13 +214,6 @@ Jobs
       :param str cluster_name: list jobs on specified cluster.
 
                                ``None`` means the current cluster (default).
-
-      :param bool materialized: filter jobs by :attr:`JobDescription.materialized` flag.
-
-      :param bool being_dropped: filter jobs by :attr:`JobDescription.being_dropped` flag.
-
-      :param bool logs_removed: filter jobs by :attr:`JobDescription.logs_removed` flag.
-
 
       :return: asynchronous iterator which emits :class:`JobDescription` objects.
 
@@ -708,19 +698,9 @@ JobDescription
       cannot be scheduled because the lack of computation
       cluster resources (memory, CPU/GPU etc), :class:`float`
 
-   .. attribute:: materialized
+   .. attribute:: _internal
 
-      Is low-level execution instance (e.g. k8s pod) exists for this job, :class:`bool`
-
-   .. attribute:: being_dropped
-
-      Is this job being removed from servers database. Some functionality can
-      work improperly for such job. :class:`bool`
-
-   .. attribute:: logs_removed
-
-      Is logs were removed from this job. This flag can only be set when
-      :attr:`~JobDescription.being_dropped` flag is set. :class:`bool`
+      Some internal info about job used by platform. Should not be used.
 
 
 JobRestartPolicy

--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -144,6 +144,9 @@ Jobs
                       reverse: bool = False, \
                       limit: Optional[int] = None, \
                       cluster_name: Optional[str] = None, \
+                      materialized: Optional[bool] = None, \
+                      being_dropped: Optional[bool] = False, \
+                      logs_removed: Optional[bool] = False, \
                  ) -> AsyncContextManager[AsyncIterator[JobDescription]]
       :async-with:
       :async-for:
@@ -214,6 +217,13 @@ Jobs
       :param str cluster_name: list jobs on specified cluster.
 
                                ``None`` means the current cluster (default).
+
+      :param bool materialized: filter jobs by :attr:`JobDescription.materialized` flag.
+
+      :param bool being_dropped: filter jobs by :attr:`JobDescription.being_dropped` flag.
+
+      :param bool logs_removed: filter jobs by :attr:`JobDescription.logs_removed` flag.
+
 
       :return: asynchronous iterator which emits :class:`JobDescription` objects.
 
@@ -697,6 +707,21 @@ JobDescription
       Minimal timeout in seconds job will wait before reporting it
       cannot be scheduled because the lack of computation
       cluster resources (memory, CPU/GPU etc), :class:`float`
+
+   .. attribute:: materialized
+
+      Is low-level execution instance (e.g. k8s pod) exists for this job, :class:`bool`
+
+   .. attribute:: being_dropped
+
+      Is this job being removed from servers database. Some functionality can
+      work improperly for such job. :class:`bool`
+
+   .. attribute:: logs_removed
+
+      Is logs were removed from this job. This flag can only be set when
+      :attr:`~JobDescription.being_dropped` flag is set. :class:`bool`
+
 
 JobRestartPolicy
 ================

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -220,6 +220,9 @@ class JobDescription:
     preset_name: Optional[str] = None
     preemptible_node: bool = False
     privileged: bool = False
+    materialized: bool = False
+    being_dropped: bool = False
+    logs_removed: bool = False
 
 
 @dataclass(frozen=True)
@@ -404,6 +407,9 @@ class Jobs(metaclass=NoPublicConstructor):
         reverse: bool = False,
         limit: Optional[int] = None,
         cluster_name: Optional[str] = None,
+        materialized: Optional[bool] = None,
+        being_dropped: Optional[bool] = False,
+        logs_removed: Optional[bool] = False,
     ) -> AsyncIterator[JobDescription]:
         url = self._config.api_url / "jobs"
         headers = {"Accept": "application/x-ndjson"}
@@ -432,6 +438,12 @@ class Jobs(metaclass=NoPublicConstructor):
             params.add("reverse", "1")
         if limit is not None:
             params.add("limit", str(limit))
+        if materialized is not None:
+            params.add("materialized", str(materialized))
+        if being_dropped is not None:
+            params.add("being_dropped", str(being_dropped))
+        if logs_removed is not None:
+            params.add("logs_removed", str(logs_removed))
         auth = await self._config._api_auth()
         async with self._core.request(
             "GET", url, headers=headers, params=params, auth=auth
@@ -1005,6 +1017,9 @@ def _job_description_from_api(res: Dict[str, Any], parse: Parser) -> JobDescript
         life_span=life_span,
         schedule_timeout=res.get("schedule_timeout", None),
         preset_name=res.get("preset_name"),
+        materialized=res.get("materialized", False),
+        being_dropped=res.get("being_dropped", False),
+        logs_removed=res.get("logs_removed", False),
     )
 
 

--- a/neuro-sdk/tests/test_jobs.py
+++ b/neuro-sdk/tests/test_jobs.py
@@ -579,8 +579,8 @@ async def test_status_being_dropped(
         ret = await client.jobs.status("job-id")
 
         assert ret == _job_description_from_api(JSON, client.parse)
-        assert ret.being_dropped
-        assert ret.logs_removed
+        assert ret._internal.being_dropped
+        assert ret._internal.logs_removed
 
 
 async def test_status_with_http(

--- a/neuro-sdk/tests/test_jobs.py
+++ b/neuro-sdk/tests/test_jobs.py
@@ -518,6 +518,71 @@ async def test_status_failed(
         assert ret.preemptible_node
 
 
+async def test_status_being_dropped(
+    aiohttp_server: _TestServerFactory, make_client: _MakeClient
+) -> None:
+    JSON = {
+        "status": "failed",
+        "id": "job-id",
+        "description": "This is job description, not a history description",
+        "http_url": "http://my_host:8889",
+        "history": {
+            "created_at": "2018-08-29T12:23:13.981621+00:00",
+            "started_at": "2018-08-29T12:23:15.988054+00:00",
+            "finished_at": "2018-08-29T12:59:31.427795+00:00",
+            "reason": "ContainerCannotRun",
+            "description": "Not enough coffee",
+        },
+        "scheduler_enabled": True,
+        "preemptible_node": True,
+        "pass_config": False,
+        "being_dropped": True,
+        "logs_removed": True,
+        "owner": "owner",
+        "cluster_name": "default",
+        "uri": "job://default/owner/job-id",
+        "container": {
+            "image": "submit-image-name",
+            "command": "submit-command",
+            "http": {"port": 8181},
+            "resources": {
+                "memory_mb": "4096",
+                "cpu": 7.0,
+                "shm": True,
+                "gpu": 1,
+                "gpu_model": "test-gpu-model",
+            },
+            "volumes": [
+                {
+                    "src_storage_uri": "storage://test-user/path_read_only",
+                    "dst_path": "/container/read_only",
+                    "read_only": True,
+                },
+                {
+                    "src_storage_uri": "storage://test-user/path_read_write",
+                    "dst_path": "/container/path_read_write",
+                    "read_only": False,
+                },
+            ],
+        },
+    }
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response(JSON)
+
+    app = web.Application()
+    app.router.add_get("/jobs/job-id", handler)
+
+    srv = await aiohttp_server(app)
+
+    async with make_client(srv.make_url("/")) as client:
+        ret = await client.jobs.status("job-id")
+
+        assert ret == _job_description_from_api(JSON, client.parse)
+        assert ret.being_dropped
+        assert ret.logs_removed
+
+
 async def test_status_with_http(
     aiohttp_server: _TestServerFactory, make_client: _MakeClient
 ) -> None:


### PR DESCRIPTION
Blocked by https://github.com/neuro-inc/platform-api/pull/1630

As platform-monitoring uses SDK to fetch jobs and it needs `being_dropped` and `logs_removed` fields to be able to clean up dropped jobs, we have to add this fields to SDK. I do not completely like the idea to expose these fields to public API, but on another side, it is much better than to have to reimplement "jobs client" in each service.

I use the term "dropped" instead of "deleted" because we already have `jobs_for_deletion` method in `platform-api` which means "jobs to be deleted from k8s".