### PR TITLE
Cluster cli option

### DIFF
--- a/CHANGELOG.D/2225.feature
+++ b/CHANGELOG.D/2225.feature
@@ -1,0 +1,2 @@
+Added `--cluster` option to `neuro run` command and `neuro disk`, `neuro secret` command groups. This option
+allows to perform actions for a specific cluster instead of current one.

--- a/CLI.md
+++ b/CLI.md
@@ -2120,6 +2120,7 @@ neuro secret ls [OPTIONS]
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Look on a specified cluster \(the current cluster by default).|
 |_\--full-uri_|Output full disk URI.|
 
 
@@ -2149,6 +2150,7 @@ neuro secret add KEY_NAME @path/to/file.txt
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Perform on a specified cluster \(the current cluster by default).|
 
 
 
@@ -2168,6 +2170,7 @@ neuro secret rm [OPTIONS] KEY
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Perform on a specified cluster \(the current cluster by default).|
 
 
 
@@ -2216,7 +2219,7 @@ neuro disk ls [OPTIONS]
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster CLUSTER_|Show disks on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Look on a specified cluster \(the current cluster by default).|
 |_\--full-uri_|Output full disk URI.|
 |_\--long-format_|Output all info about disk.|
 
@@ -2247,7 +2250,7 @@ neuro disk create 500M
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster CLUSTER_|Create disk in a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Perform in a specified cluster \(the current cluster by default).|
 |_--name NAME_|Optional disk name|
 |_\--timeout-unused TIMEDELTA_|Optional disk lifetime limit after last usage in the format '1d2h3m4s' \(some parts may be missing). Set '0' to disable. Default value '1d' can be changed in the user config.|
 

--- a/CLI.md
+++ b/CLI.md
@@ -565,6 +565,7 @@ Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
 |_--browse_|Open a job's URL in a web browser|
+|_--cluster CLUSTER_|Run job in a specified cluster|
 |_\-d, --description DESC_|Optional job description in free format|
 |_--detach_|Don't attach to job logs and don't wait for exit code|
 |_--entrypoint TEXT_|Executable entrypoint in the container \(note that it overwrites `ENTRYPOINT` and `CMD` instructions of the docker image)|
@@ -650,7 +651,7 @@ Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
 |_\-a, --all_|Show all jobs regardless the status.|
-|_--cluster TEXT_|Show jobs on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show jobs on a specified cluster \(the current cluster by default).|
 |_\-d, --description DESCRIPTION_|Filter out jobs by description \(exact match).|
 |_--distinct_|Show only first job if names are same.|
 |_--format COLUMNS_|Output table format, see "neuro help ps\-format" for more info about the format specification. The default can be changed using the job.ps-format configuration variable documented in "neuro help user-config"|
@@ -823,7 +824,7 @@ neuro top -t tag1 -t tag2
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster TEXT_|Show jobs on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show jobs on a specified cluster \(the current cluster by default).|
 |_\-d, --description DESCRIPTION_|Filter out jobs by description \(exact match).|
 |_--format COLUMNS_|Output table format, see "neuro help top\-format" for more info about the format specification. The default can be changed using the job.top-format configuration variable documented in "neuro help user-config"|
 |_\--full-uri_|Output full image URI.|
@@ -1307,7 +1308,7 @@ neuro image ls [OPTIONS]
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster TEXT_|Show images on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show images on a specified cluster \(the current cluster by default).|
 |_-l_|List in long format.|
 |_\--full-uri_|Output full image URI.|
 |_\-n, --name PATTERN_|Filter out images by name regex.|
@@ -2215,6 +2216,7 @@ neuro disk ls [OPTIONS]
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Show disks on a specified cluster \(the current cluster by default).|
 |_\--full-uri_|Output full disk URI.|
 |_\--long-format_|Output all info about disk.|
 
@@ -2245,6 +2247,7 @@ neuro disk create 500M
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Create disk in a specified cluster \(the current cluster by default).|
 |_--name NAME_|Optional disk name|
 |_\--timeout-unused TIMEDELTA_|Optional disk lifetime limit after last usage in the format '1d2h3m4s' \(some parts may be missing). Set '0' to disable. Default value '1d' can be changed in the user config.|
 
@@ -2266,6 +2269,7 @@ neuro disk get [OPTIONS] DISK
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Look on a specified cluster \(the current cluster by default).|
 |_\--full-uri_|Output full disk URI.|
 
 
@@ -2286,6 +2290,7 @@ neuro disk rm [OPTIONS] DISKS...
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
+|_--cluster CLUSTER_|Perform on a specified cluster \(the current cluster by default).|
 
 
 
@@ -2449,6 +2454,7 @@ Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
 |_--browse_|Open a job's URL in a web browser|
+|_--cluster CLUSTER_|Run job in a specified cluster|
 |_\-d, --description DESC_|Optional job description in free format|
 |_--detach_|Don't attach to job logs and don't wait for exit code|
 |_--entrypoint TEXT_|Executable entrypoint in the container \(note that it overwrites `ENTRYPOINT` and `CMD` instructions of the docker image)|
@@ -2506,7 +2512,7 @@ Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
 |_\-a, --all_|Show all jobs regardless the status.|
-|_--cluster TEXT_|Show jobs on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show jobs on a specified cluster \(the current cluster by default).|
 |_\-d, --description DESCRIPTION_|Filter out jobs by description \(exact match).|
 |_--distinct_|Show only first job if names are same.|
 |_--format COLUMNS_|Output table format, see "neuro help ps\-format" for more info about the format specification. The default can be changed using the job.ps-format configuration variable documented in "neuro help user-config"|
@@ -2699,7 +2705,7 @@ neuro top -t tag1 -t tag2
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster TEXT_|Show jobs on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show jobs on a specified cluster \(the current cluster by default).|
 |_\-d, --description DESCRIPTION_|Filter out jobs by description \(exact match).|
 |_--format COLUMNS_|Output table format, see "neuro help top\-format" for more info about the format specification. The default can be changed using the job.top-format configuration variable documented in "neuro help user-config"|
 |_\--full-uri_|Output full image URI.|
@@ -2978,7 +2984,7 @@ neuro images [OPTIONS]
 Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
-|_--cluster TEXT_|Show images on a specified cluster \(the current cluster by default).|
+|_--cluster CLUSTER_|Show images on a specified cluster \(the current cluster by default).|
 |_-l_|List in long format.|
 |_\--full-uri_|Output full image URI.|
 |_\-n, --name PATTERN_|Filter out images by name regex.|

--- a/neuro-cli/docs/disk.md
+++ b/neuro-cli/docs/disk.md
@@ -37,6 +37,7 @@ List disks.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Show disks on a specified cluster \(the current cluster by default\). |
 | _--full-uri_ | Output full disk URI. |
 | _--long-format_ | Output all info about disk. |
 
@@ -83,6 +84,7 @@ $ neuro disk create 500M
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Create disk in a specified cluster \(the current cluster by default\). |
 | _--name NAME_ | Optional disk name |
 | _--timeout-unused TIMEDELTA_ | Optional disk lifetime limit after last usage in the format '1d2h3m4s' \(some parts may be missing\). Set '0' to disable. Default value '1d' can be changed in the user config. |
 
@@ -106,6 +108,7 @@ Get disk `DISK`_ID.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Look on a specified cluster \(the current cluster by default\). |
 | _--full-uri_ | Output full disk URI. |
 
 
@@ -128,5 +131,6 @@ Remove disk `DISK`_ID.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Perform on a specified cluster \(the current cluster by default\). |
 
 

--- a/neuro-cli/docs/disk.md
+++ b/neuro-cli/docs/disk.md
@@ -37,7 +37,7 @@ List disks.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster CLUSTER_ | Show disks on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Look on a specified cluster \(the current cluster by default\). |
 | _--full-uri_ | Output full disk URI. |
 | _--long-format_ | Output all info about disk. |
 
@@ -84,7 +84,7 @@ $ neuro disk create 500M
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster CLUSTER_ | Create disk in a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Perform in a specified cluster \(the current cluster by default\). |
 | _--name NAME_ | Optional disk name |
 | _--timeout-unused TIMEDELTA_ | Optional disk lifetime limit after last usage in the format '1d2h3m4s' \(some parts may be missing\). Set '0' to disable. Default value '1d' can be changed in the user config. |
 

--- a/neuro-cli/docs/image.md
+++ b/neuro-cli/docs/image.md
@@ -40,7 +40,7 @@ List images.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster TEXT_ | Show images on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show images on a specified cluster \(the current cluster by default\). |
 | _-l_ | List in long format. |
 | _--full-uri_ | Output full image URI. |
 | _-n, --name PATTERN_ | Filter out images by name regex. |

--- a/neuro-cli/docs/job.md
+++ b/neuro-cli/docs/job.md
@@ -69,6 +69,7 @@ $ neuro run -s cpu-small image:my-ubuntu:latest --entrypoint=/script.sh arg1 arg
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
 | _--browse_ | Open a job's URL in a web browser |
+| _--cluster CLUSTER_ | Run job in a specified cluster |
 | _-d, --description DESC_ | Optional job description in free format |
 | _--detach_ | Don't attach to job logs and don't wait for exit code |
 | _--entrypoint TEXT_ | Executable entrypoint in the container \(note that it overwrites `ENTRYPOINT` and `CMD` instructions of the docker image\) |
@@ -156,7 +157,7 @@ $ neuro ps -t tag1 -t tag2
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
 | _-a, --all_ | Show all jobs regardless the status. |
-| _--cluster TEXT_ | Show jobs on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show jobs on a specified cluster \(the current cluster by default\). |
 | _-d, --description DESCRIPTION_ | Filter out jobs by description \(exact match\). |
 | _--distinct_ | Show only first job if names are same. |
 | _--format COLUMNS_ | Output table format, see "neuro help ps-format" for more info about the format specification. The default can be changed using the job.ps-format configuration variable documented in "neuro help user-config" |
@@ -338,7 +339,7 @@ $ neuro top -t tag1 -t tag2
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster TEXT_ | Show jobs on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show jobs on a specified cluster \(the current cluster by default\). |
 | _-d, --description DESCRIPTION_ | Filter out jobs by description \(exact match\). |
 | _--format COLUMNS_ | Output table format, see "neuro help top-format" for more info about the format specification. The default can be changed using the job.top-format configuration variable documented in "neuro help user-config" |
 | _--full-uri_ | Output full image URI. |

--- a/neuro-cli/docs/secret.md
+++ b/neuro-cli/docs/secret.md
@@ -36,6 +36,7 @@ List secrets.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Look on a specified cluster \(the current cluster by default\). |
 | _--full-uri_ | Output full disk URI. |
 
 
@@ -69,6 +70,7 @@ $ neuro secret add KEY_NAME @path/to/file.txt
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Perform on a specified cluster \(the current cluster by default\). |
 
 
 
@@ -90,5 +92,6 @@ Remove secret `KEY`.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
+| _--cluster CLUSTER_ | Perform on a specified cluster \(the current cluster by default\). |
 
 

--- a/neuro-cli/docs/shortcuts.md
+++ b/neuro-cli/docs/shortcuts.md
@@ -66,6 +66,7 @@ $ neuro run -s cpu-small image:my-ubuntu:latest --entrypoint=/script.sh arg1 arg
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
 | _--browse_ | Open a job's URL in a web browser |
+| _--cluster CLUSTER_ | Run job in a specified cluster |
 | _-d, --description DESC_ | Optional job description in free format |
 | _--detach_ | Don't attach to job logs and don't wait for exit code |
 | _--entrypoint TEXT_ | Executable entrypoint in the container \(note that it overwrites `ENTRYPOINT` and `CMD` instructions of the docker image\) |
@@ -124,7 +125,7 @@ $ neuro ps -t tag1 -t tag2
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
 | _-a, --all_ | Show all jobs regardless the status. |
-| _--cluster TEXT_ | Show jobs on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show jobs on a specified cluster \(the current cluster by default\). |
 | _-d, --description DESCRIPTION_ | Filter out jobs by description \(exact match\). |
 | _--distinct_ | Show only first job if names are same. |
 | _--format COLUMNS_ | Output table format, see "neuro help ps-format" for more info about the format specification. The default can be changed using the job.ps-format configuration variable documented in "neuro help user-config" |
@@ -328,7 +329,7 @@ $ neuro top -t tag1 -t tag2
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster TEXT_ | Show jobs on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show jobs on a specified cluster \(the current cluster by default\). |
 | _-d, --description DESCRIPTION_ | Filter out jobs by description \(exact match\). |
 | _--format COLUMNS_ | Output table format, see "neuro help top-format" for more info about the format specification. The default can be changed using the job.top-format configuration variable documented in "neuro help user-config" |
 | _--full-uri_ | Output full image URI. |
@@ -652,7 +653,7 @@ List images.
 | Name | Description |
 | :--- | :--- |
 | _--help_ | Show this message and exit. |
-| _--cluster TEXT_ | Show images on a specified cluster \(the current cluster by default\). |
+| _--cluster CLUSTER_ | Show images on a specified cluster \(the current cluster by default\). |
 | _-l_ | List in long format. |
 | _--full-uri_ | Output full image URI. |
 | _-n, --name PATTERN_ | Filter out images by name regex. |

--- a/neuro-cli/src/neuro_cli/click_types.py
+++ b/neuro-cli/src/neuro_cli/click_types.py
@@ -258,7 +258,7 @@ class PresetType(AsyncType[str]):
     ) -> str:
         client = await root.init_client()
         if value not in self._get_presets(ctx, client):
-            cluster_name = None
+            cluster_name = client.cluster_name
             if ctx:
                 cluster_name = ctx.params.get("cluster", client.cluster_name)
             if cluster_name != client.cluster_name:
@@ -267,7 +267,7 @@ class PresetType(AsyncType[str]):
                 )
             else:
                 error_message = f"Preset {value} is not valid, "
-                "run 'neuro config show' to get a list of available presets",
+                "run 'neuro config show' to get a list of available presets"
             raise click.BadParameter(
                 error_message,
                 ctx,
@@ -299,7 +299,7 @@ class ClusterType(AsyncType[str]):
         ctx: Optional[click.Context],
     ) -> str:
         client = await root.init_client()
-        if value not in client.config.clusters.keys():
+        if value not in client.config.clusters:
             raise click.BadParameter(
                 f"Cluster {value} is not valid, "
                 "run 'neuro config get-clusters' to get a list of available clusters",
@@ -314,8 +314,8 @@ class ClusterType(AsyncType[str]):
         # async context manager is used to prevent a message about
         # unclosed session
         async with await root.init_client() as client:
-            presets = list(client.config.clusters)
-            return [(p, None) for p in presets if p.startswith(incomplete)]
+            clusters = list(client.config.clusters)
+            return [(c, None) for c in clusters if c.startswith(incomplete)]
 
 
 CLUSTER = ClusterType()

--- a/neuro-cli/src/neuro_cli/disks.py
+++ b/neuro-cli/src/neuro_cli/disks.py
@@ -30,7 +30,7 @@ def disk() -> None:
 @option(
     "--cluster",
     type=CLUSTER,
-    help="Show disks on a specified cluster (the current cluster by default).",
+    help="Look on a specified cluster (the current cluster by default).",
 )
 @option("--full-uri", is_flag=True, help="Output full disk URI.")
 @option("--long-format", is_flag=True, help="Output all info about disk.")
@@ -47,7 +47,8 @@ async def ls(
             uri_fmtr: URIFormatter = str
         else:
             uri_fmtr = uri_formatter(
-                username=root.client.username, cluster_name=root.client.cluster_name
+                username=root.client.username,
+                cluster_name=cluster or root.client.cluster_name,
             )
         disks_fmtr = DisksFormatter(
             uri_fmtr,
@@ -71,7 +72,7 @@ async def ls(
 @option(
     "--cluster",
     type=CLUSTER,
-    help="Create disk in a specified cluster (the current cluster by default).",
+    help="Perform in a specified cluster (the current cluster by default).",
 )
 @option(
     "--timeout-unused",
@@ -154,7 +155,8 @@ async def get(root: Root, cluster: Optional[str], disk: str, full_uri: bool) -> 
         uri_fmtr: URIFormatter = str
     else:
         uri_fmtr = uri_formatter(
-            username=root.client.username, cluster_name=root.client.cluster_name
+            username=root.client.username,
+            cluster_name=cluster or root.client.cluster_name,
         )
     disk_fmtr = DiskFormatter(
         uri_fmtr, datetime_formatter=get_datetime_formatter(root.iso_datetime_format)

--- a/neuro-cli/src/neuro_cli/image.py
+++ b/neuro-cli/src/neuro_cli/image.py
@@ -21,7 +21,7 @@ from neuro_cli.formatters.images import (
 )
 from neuro_cli.formatters.utils import ImageFormatter, image_formatter, uri_formatter
 
-from .click_types import RemoteImageType
+from .click_types import CLUSTER, RemoteImageType
 from .root import Root
 from .utils import (
     argument,
@@ -110,6 +110,7 @@ async def pull(root: Root, remote_image: str, local_image: Optional[str]) -> Non
 @command()
 @option(
     "--cluster",
+    type=CLUSTER,
     help="Show images on a specified cluster (the current cluster by default).",
 )
 @option("-l", "format_long", is_flag=True, help="List in long format.")

--- a/neuro-cli/src/neuro_cli/utils.py
+++ b/neuro-cli/src/neuro_cli/utils.py
@@ -486,12 +486,14 @@ async def resolve_job_ex(
 DISK_ID_PATTERN = r"disk-[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
 
 
-async def resolve_disk(id_or_name: str, *, client: Client) -> str:
+async def resolve_disk(
+    id_or_name: str, *, client: Client, cluster_name: Optional[str] = None
+) -> str:
     # Temporary fast path.
     if re.fullmatch(DISK_ID_PATTERN, id_or_name):
         return id_or_name
 
-    disk = await client.disks.get(id_or_name)
+    disk = await client.disks.get(id_or_name, cluster_name)
     return disk.id
 
 

--- a/neuro-sdk/docs/disks_reference.rst
+++ b/neuro-sdk/docs/disks_reference.rst
@@ -13,15 +13,18 @@ Disks
 
    Persistent disks subsystems. Disks can be passed as mounted volumes into a running job.
 
-   .. comethod:: list() -> AsyncContextManager[AsyncIterator[Disk]]
+   .. comethod:: list(cluster_name: Optional[str] = None) -> AsyncContextManager[AsyncIterator[Disk]]
       :async-for:
 
       List user's disks, async iterator. Yields :class:`Disk` instances.
+
+      :param str cluster_name: cluster to list a disks. Default is current cluster.
 
    .. comethod:: create(  \
                         storage: int, \
                         life_span: typing.Optional[datetime.timedelta], \
                         name: typing.Optional[str], \
+                        cluster_name: Optional[str] = None, \
                  ) -> Disk
 
       Create a disk with capacity of *storage* bytes.
@@ -35,21 +38,28 @@ Disks
       :param ~typing.Optional[str] name: Name of the disk. Should be unique among all user's
                                          disk.
 
+      :param str cluster_name: cluster to create a disk. Default is current cluster.
+
+
       :return: Newly created disk info (:class:`Disk`)
 
-   .. comethod:: get(disk_id_or_name: str) -> Disk
+   .. comethod:: get(disk_id_or_name: str, cluster_name: Optional[str] = None) -> Disk
 
       Get a disk with id or name *disk_id_or_name*.
 
       :param str disk_id_or_name: disk's id or name.
 
+      :param str cluster_name: cluster to look for a disk. Default is current cluster.
+
       :return: Disk info (:class:`Disk`)
 
-   .. comethod:: rm(disk_id_or_name: str) -> None
+   .. comethod:: rm(disk_id_or_name: str, cluster_name: Optional[str] = None) -> None
 
       Delete a disk with id or name *disk_id_or_name*.
 
       :param str disk_id_or_name: disk's id or name.
+
+      :param str cluster_name: cluster to look for a disk. Default is current cluster.
 
 
 Disk

--- a/neuro-sdk/docs/disks_reference.rst
+++ b/neuro-sdk/docs/disks_reference.rst
@@ -18,7 +18,7 @@ Disks
 
       List user's disks, async iterator. Yields :class:`Disk` instances.
 
-      :param str cluster_name: cluster to list a disks. Default is current cluster.
+      :param str cluster_name: cluster to list disks. Default is current cluster.
 
    .. comethod:: create(  \
                         storage: int, \

--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -328,6 +328,7 @@ Jobs
    .. comethod:: start(*, \
                        image: RemoteImage, \
                        preset_name: str, \
+                       cluster_name: Optional[str] = None, \
                        entrypoint: Optional[str] = None, \
                        command: Optional[str] = None, \
                        working_dir: Optional[str] = None, \
@@ -355,6 +356,8 @@ Jobs
       :param RemoteImage image: image used for starting a container.
 
       :param str preset_name: name of the preset of resources given to a container on a node.
+
+      :param str cluster_name: cluster to start a job. Default is current cluster.
 
       :param str entrypoint: optional Docker ENTRYPOINT_ used for overriding image entry-point
                              (:class:`str`), default ``None`` is used to pick entry-point

--- a/neuro-sdk/docs/secrets_reference.rst
+++ b/neuro-sdk/docs/secrets_reference.rst
@@ -14,13 +14,15 @@ Secrets
    Secured secrets subsystems.  Secrets can be passed as mounted files and environment
    variables into a running job.
 
-   .. comethod:: list() -> AsyncContextManager[AsyncIterator[Secret]]
+   .. comethod:: list(cluster_name: Optional[str] = None) -> AsyncContextManager[AsyncIterator[Secret]]
       :async-with:
       :async-for:
 
       List user's secrets, async iterator. Yields :class:`Secret` instances.
 
-   .. comethod:: add(key: str, value: bytes) -> None
+      :param str cluster_name: cluster to list secrets. Default is current cluster.
+
+   .. comethod:: add(key: str, value: bytes, cluster_name: Optional[str] = None) -> None
 
       Add a secret with name *key* and content *value*.
 
@@ -28,8 +30,12 @@ Secrets
 
       :param bytes vale: secret's value.
 
-   .. comethod:: rm(key: str) -> None
+      :param str cluster_name: cluster to create a secret. Default is current cluster.
+
+   .. comethod:: rm(key: str, cluster_name: Optional[str] = None) -> None
 
       Delete a secret *key*.
 
       :param str key: secret's name.
+
+      :param str cluster_name: cluster to look for a secret. Default is current cluster.

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -307,7 +307,7 @@ class Jobs(metaclass=NoPublicConstructor):
     ) -> JobDescription:
         url = self._config.api_url / "jobs"
         payload = _job_to_api(
-            config=self._config,
+            cluster_name=self._config.cluster_name,
             name=name,
             tags=tags,
             description=description,
@@ -343,6 +343,7 @@ class Jobs(metaclass=NoPublicConstructor):
         *,
         image: RemoteImage,
         preset_name: str,
+        cluster_name: Optional[str] = None,
         entrypoint: Optional[str] = None,
         command: Optional[str] = None,
         working_dir: Optional[str] = None,
@@ -381,7 +382,7 @@ class Jobs(metaclass=NoPublicConstructor):
             shm=shm,
         )
         payload = _job_to_api(
-            config=self._config,
+            cluster_name=cluster_name or self._config.cluster_name,
             name=name,
             preset_name=preset_name,
             tags=tags,
@@ -1031,7 +1032,7 @@ def _job_description_from_api(res: Dict[str, Any], parse: Parser) -> JobDescript
 
 
 def _job_to_api(
-    config: Config,
+    cluster_name: str,
     name: Optional[str] = None,
     preset_name: Optional[str] = None,
     tags: Sequence[str] = (),
@@ -1062,7 +1063,7 @@ def _job_to_api(
         primitive["wait_for_jobs_quota"] = wait_for_jobs_quota
     if privileged:
         primitive["privileged"] = privileged
-    primitive["cluster_name"] = config.cluster_name
+    primitive["cluster_name"] = cluster_name
     return primitive
 
 


### PR DESCRIPTION
This allows running some operations for a specific cluster instead of the current one. This can be helpful when the user wants to write a script that migrates a lot of data from one cluster to another.