### PR TITLE
Fix set_user_quota if credits == 0

### DIFF
--- a/CHANGELOG.D/2229.bugfix
+++ b/CHANGELOG.D/2229.bugfix
@@ -1,0 +1,1 @@
+`_Admin.set_user_quota` method is fixed for cases, when the amount of credits equals to zero.

--- a/neuro-sdk/src/neuro_sdk/admin.py
+++ b/neuro-sdk/src/neuro_sdk/admin.py
@@ -170,7 +170,7 @@ class _Admin(metaclass=NoPublicConstructor):
         )
         payload = {
             "quota": {
-                "credits": str(credits) if credits else None,
+                "credits": str(credits) if credits is not None else None,
                 "total_running_jobs": total_running_jobs,
             },
         }

--- a/neuro-sdk/tests/test_admin.py
+++ b/neuro-sdk/tests/test_admin.py
@@ -470,11 +470,13 @@ async def test_set_user_quota(
     async with make_client(srv.make_url("/api/v1")) as client:
         await client._admin.set_user_quota("default", "ivan", Decimal("1000"), 10)
         await client._admin.set_user_quota("neuro", "user2", None, None)
+        await client._admin.set_user_quota("neuro", "user3", 0, None)
         assert requested_cluster_users == [
             ("default", "ivan"),
             ("neuro", "user2"),
+            ("neuro", "user3"),
         ]
-        assert len(requested_payloads) == 2
+        assert len(requested_payloads) == 3
         assert {
             "quota": {
                 "credits": "1000",
@@ -482,6 +484,11 @@ async def test_set_user_quota(
             },
         } in requested_payloads
         assert {"quota": {}} in requested_payloads
+        assert {
+            "quota": {
+                "credits": "0",
+            },
+        } in requested_payloads
 
 
 async def test_add_user_quota(


### PR DESCRIPTION
In this case, we set credits to 'infinity', since [this](https://github.com/neuro-inc/platform-client-python/compare/ys/fix_set_usr_credits?expand=1#diff-88fbede459d7e6bdef38fc1ed9cdeb85e143080e793cadfe96ecb33a5e34155cR173) line evaluates to None, which is improper. 