### PR TITLE
Add possiblity to disable pypi version check via setting env var

### DIFF
--- a/CHANGELOG.D/2237.feature
+++ b/CHANGELOG.D/2237.feature
@@ -1,0 +1,1 @@
+Added possibility to disable PyPi version check via environment variable 'NEURO_CLI_DISABLE_PYPI_VERSION_CHECK'.

--- a/CLI.md
+++ b/CLI.md
@@ -125,7 +125,7 @@ Name | Description|
 |----|------------|
 |_--help_|Show this message and exit.|
 |_--color \[yes &#124; no &#124; auto]_|Color mode.|
-|_\--disable-pypi-version-check_|Don't periodically check PyPI to determine whether a new version of Neuro Platform CLI is available for download.|
+|_\--disable-pypi-version-check_|Don't periodically check PyPI to determine whether a new version of Neuro Platform CLI is available for download.  \[env var: NEURO\_CLI_DISABLE_PYPI_VERSION_CHECK]|
 |_\--hide-token / --no-hide-token_|Prevent user's token sent in HTTP headers from being printed out to stderr during HTTP tracing. Can be used only together with option '--trace'. On by default.|
 |_\--iso-datetime-format / --no-iso-datetime-format_|Use ISO 8601 format for printing date and time|
 |_\--network-timeout FLOAT_|Network read timeout, seconds.|

--- a/neuro-cli/src/neuro_cli/main.py
+++ b/neuro-cli/src/neuro_cli/main.py
@@ -364,6 +364,7 @@ def print_options(
 @option(
     "--disable-pypi-version-check",
     is_flag=True,
+    default=click.BOOL(os.environ.get("NEURO_CLI_DISABLE_PYPI_VERSION_CHECK", False)),
     help="Don't periodically check PyPI to determine whether a new version of "
     "Neuro Platform CLI is available for download.",
 )

--- a/neuro-cli/src/neuro_cli/main.py
+++ b/neuro-cli/src/neuro_cli/main.py
@@ -364,7 +364,8 @@ def print_options(
 @option(
     "--disable-pypi-version-check",
     is_flag=True,
-    default=click.BOOL(os.environ.get("NEURO_CLI_DISABLE_PYPI_VERSION_CHECK", False)),
+    envvar="NEURO_CLI_DISABLE_PYPI_VERSION_CHECK",
+    show_envvar=True,
     help="Don't periodically check PyPI to determine whether a new version of "
     "Neuro Platform CLI is available for download.",
 )


### PR DESCRIPTION
We need to suppress version checks in different tools, which might have a lag before the release with the latest versions (such as neuromation base environment docker image, neuro-web-shell, etc.)

As an alternative - we could also utilize the [auto_envvar_prefix](https://click.palletsprojects.com/en/8.0.x/options/#dynamic-defaults-for-prompts) feature from click, but I'm not sure whether we need that thing at the moment.

