### PR TITLE
Add parameter separator in jobs.monitor().

### DIFF
--- a/CHANGELOG.D/2239.feature
+++ b/CHANGELOG.D/2239.feature
@@ -1,0 +1,1 @@
+Add parameter *separator* in jobs.monitor().

--- a/neuro-cli/src/neuro_cli/ael.py
+++ b/neuro-cli/src/neuro_cli/ael.py
@@ -79,7 +79,10 @@ async def process_logs(
 ) -> None:
     codec_info = codecs.lookup("utf8")
     decoder = codec_info.incrementaldecoder("replace")
-    async with root.client.jobs.monitor(job, cluster_name=cluster_name) as it:
+    separator = "<================ Live logs ==============>"
+    async with root.client.jobs.monitor(
+        job, cluster_name=cluster_name, separator=separator
+    ) as it:
         async for chunk in it:
             if not chunk:
                 txt = decoder.decode(b"", final=True)

--- a/neuro-sdk/docs/jobs_reference.rst
+++ b/neuro-sdk/docs/jobs_reference.rst
@@ -220,6 +220,7 @@ Jobs
 
    .. comethod:: monitor(id: str, *, \
                          cluster_name: Optional[str] = None, \
+                         separator: Optional[str] = None,
                  ) -> AsyncContextManager[AsyncIterator[bytes]]
       :async-with:
       :async-for:
@@ -235,6 +236,12 @@ Jobs
       :param str cluster_name: cluster on which the job is running.
 
                                ``None`` means the current cluster (default).
+
+      :param str separator: string which will separate archive and live logs
+                            (if both parts are present).
+
+                            By default a string containing random characters are used.
+                            Empty *separator* suppresses output of separator.
 
       :return: :class:`~collections.abc.AsyncIterator` over :class:`bytes` log chunks.
 

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -484,9 +484,15 @@ class Jobs(metaclass=NoPublicConstructor):
 
     @asyncgeneratorcontextmanager
     async def monitor(
-        self, id: str, *, cluster_name: Optional[str] = None
+        self,
+        id: str,
+        *,
+        cluster_name: Optional[str] = None,
+        separator: Optional[str] = None,
     ) -> AsyncIterator[bytes]:
         url = self._get_monitoring_url(cluster_name) / id / "log"
+        if separator is not None:
+            url = url.update_query(separator=separator)
         timeout = attr.evolve(self._core.timeout, sock_read=None)
         auth = await self._config._api_auth()
         async with self._core.request(


### PR DESCRIPTION
Use separator "<================ Live logs ==============>" in the CLI.