### PR TITLE
Support `org_name` and job price info sent by API

### DIFF
--- a/CHANGELOG.D/2404.feature
+++ b/CHANGELOG.D/2404.feature
@@ -1,0 +1,1 @@
+Report job price in `neuro job status`, add support of organisation names in jobs.

--- a/neuro-cli/src/neuro_cli/formatters/jobs.py
+++ b/neuro-cli/src/neuro_cli/formatters/jobs.py
@@ -18,6 +18,7 @@ from rich.table import Table
 from rich.text import Text, TextType
 
 from neuro_sdk import JobDescription, JobRestartPolicy, JobStatus, JobTelemetry
+from neuro_sdk.config_factory import PASS_CONFIG_ENV_NAME
 
 from neuro_cli.formatters.utils import DatetimeFormatter
 from neuro_cli.parse_utils import JobTableFormat, JobTelemetryKeyFunc
@@ -106,6 +107,8 @@ class JobStatusFormatter:
             table.add_row("Tags", text)
         table.add_row("Owner", job_status.owner or "")
         table.add_row("Cluster", job_status.cluster_name)
+        if job_status.org_name:
+            table.add_row("Organisation", job_status.org_name)
         if job_status.description:
             table.add_row("Description", job_status.description)
         status_text = fmt_status(job_status.status)
@@ -122,6 +125,8 @@ class JobStatusFormatter:
             table.add_row("Working dir", job_status.container.working_dir)
         if job_status.preset_name:
             table.add_row("Preset", job_status.preset_name)
+        table.add_row("Price (credits / hour)", job_status.price_credits_per_hour)
+        table.add_row("Current cost", job_status.total_price_credits)
 
         resources = Table(box=None, show_header=False, show_edge=False)
         resources.add_column()
@@ -214,7 +219,10 @@ class JobStatusFormatter:
             environment.add_column("")
             environment.add_column("")
             for key, value in job_status.container.env.items():
-                environment.add_row(key, value)
+                if key == PASS_CONFIG_ENV_NAME:
+                    environment.add_row(key, "<hidden-user-token>")
+                else:
+                    environment.add_row(key, value)
             table.add_row("Environment", Styled(environment, style="reset"))
         if job_status.container.secret_env:
             secret_env = Table(box=None, show_header=False, show_edge=False)

--- a/neuro-cli/src/neuro_cli/formatters/jobs.py
+++ b/neuro-cli/src/neuro_cli/formatters/jobs.py
@@ -124,8 +124,10 @@ class JobStatusFormatter:
             table.add_row("Working dir", job_status.container.working_dir)
         if job_status.preset_name:
             table.add_row("Preset", job_status.preset_name)
-        table.add_row("Price (credits / hour)", job_status.price_credits_per_hour)
-        table.add_row("Current cost", job_status.total_price_credits)
+        table.add_row(
+            "Price (credits / hour)", f"{job_status.price_credits_per_hour:.4f}"
+        )
+        table.add_row("Current cost", f"{job_status.price_credits_per_hour:.4f}")
 
         resources = Table(box=None, show_header=False, show_edge=False)
         resources.add_column()

--- a/neuro-cli/src/neuro_cli/formatters/jobs.py
+++ b/neuro-cli/src/neuro_cli/formatters/jobs.py
@@ -18,7 +18,6 @@ from rich.table import Table
 from rich.text import Text, TextType
 
 from neuro_sdk import JobDescription, JobRestartPolicy, JobStatus, JobTelemetry
-from neuro_sdk.config_factory import PASS_CONFIG_ENV_NAME
 
 from neuro_cli.formatters.utils import DatetimeFormatter
 from neuro_cli.parse_utils import JobTableFormat, JobTelemetryKeyFunc
@@ -219,10 +218,7 @@ class JobStatusFormatter:
             environment.add_column("")
             environment.add_column("")
             for key, value in job_status.container.env.items():
-                if key == PASS_CONFIG_ENV_NAME:
-                    environment.add_row(key, "<hidden-user-token>")
-                else:
-                    environment.add_row(key, value)
+                environment.add_row(key, value)
             table.add_row("Environment", Styled(environment, style="reset"))
         if job_status.container.secret_env:
             secret_env = Table(box=None, show_header=False, show_edge=False)

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[human]_0.ref
@@ -1,13 +1,15 @@
-Job               test-job              
- Owner             owner                 
- Cluster           default               
- Description       test job description  
- Status            pending               
- Image             test-image            
- Command           test-command          
- Resources          Memory  16.0M        
-                    CPU       0.1        
- Round Robin       True                  
- Preemptible Node  True                  
- TTY               False                 
- Created           Sep 25 2018 at 12:28
+Job                     test-job              
+ Owner                   owner                 
+ Cluster                 default               
+ Description             test job description  
+ Status                  pending               
+ Image                   test-image            
+ Command                 test-command          
+ Price (credits / hour)  15                    
+ Current cost            150                   
+ Resources                Memory  16.0M        
+                          CPU       0.1        
+ Round Robin             True                  
+ Preemptible Node        True                  
+ TTY                     False                 
+ Created                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending               
  Image                   test-image            
  Command                 test-command          
- Price (credits / hour)  15                    
- Current cost            150                   
+ Price (credits / hour)  15.0000               
+ Current cost            15.0000               
  Resources                Memory  16.0M        
                           CPU       0.1        
  Round Robin             True                  

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending                          
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Round Robin             True                             

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_on_preemptible_node[iso]_0.ref
@@ -1,13 +1,15 @@
-Job               test-job                         
- Owner             owner                            
- Cluster           default                          
- Description       test job description             
- Status            pending                          
- Image             test-image                       
- Command           test-command                     
- Resources          Memory  16.0M                   
-                    CPU       0.1                   
- Round Robin       True                             
- Preemptible Node  True                             
- TTY               False                            
- Created           2018-09-25T12:28:21.298672+00:00
+Job                     test-job                         
+ Owner                   owner                            
+ Cluster                 default                          
+ Description             test job description             
+ Status                  pending                          
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Round Robin             True                             
+ Preemptible Node        True                             
+ TTY                     False                            
+ Created                 2018-09-25T12:28:21.298672+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[human]_0.ref
@@ -1,22 +1,24 @@
-Job                  test-job                                                    
- Name                 test-job-name                                               
- Owner                test-user                                                   
- Cluster              default                                                     
- Description          test job description                                        
- Status               failed (ErrorReason)                                        
- Image                image:test-image:sometag                                    
- Command              test-command                                                
- Resources             Memory  16.0M                                              
-                       CPU       0.1                                              
- TTY                  False                                                       
- Disk volumes          /mnt/disk1  disk:disk1                           READONLY  
-                       /mnt/disk2  disk:/otheruser/disk2                          
-                       /mnt/disk3  disk://othercluster/otheruser/disk3            
- Http URL             http://local.host.test/                                     
- Http port            80                                                          
- Http authentication  True                                                        
- Created              Sep 25 2018 at 12:28                                        
- Started              Sep 25 2018 at 12:28                                        
- Finished             Sep 25 2018 at 12:28                                        
- Exit code            123                                                         
- Description          ErrorDesc
+Job                     test-job                                                    
+ Name                    test-job-name                                               
+ Owner                   test-user                                                   
+ Cluster                 default                                                     
+ Description             test job description                                        
+ Status                  failed (ErrorReason)                                        
+ Image                   image:test-image:sometag                                    
+ Command                 test-command                                                
+ Price (credits / hour)  15                                                          
+ Current cost            150                                                         
+ Resources                Memory  16.0M                                              
+                          CPU       0.1                                              
+ TTY                     False                                                       
+ Disk volumes             /mnt/disk1  disk:disk1                           READONLY  
+                          /mnt/disk2  disk:/otheruser/disk2                          
+                          /mnt/disk3  disk://othercluster/otheruser/disk3            
+ Http URL                http://local.host.test/                                     
+ Http port               80                                                          
+ Http authentication     True                                                        
+ Created                 Sep 25 2018 at 12:28                                        
+ Started                 Sep 25 2018 at 12:28                                        
+ Finished                Sep 25 2018 at 12:28                                        
+ Exit code               123                                                         
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                        
  Image                   image:test-image:sometag                                    
  Command                 test-command                                                
- Price (credits / hour)  15                                                          
- Current cost            150                                                         
+ Price (credits / hour)  15.0000                                                     
+ Current cost            15.0000                                                     
  Resources                Memory  16.0M                                              
                           CPU       0.1                                              
  TTY                     False                                                       

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                        
  Image                   image:test-image:sometag                                    
  Command                 test-command                                                
- Price (credits / hour)  15                                                          
- Current cost            150                                                         
+ Price (credits / hour)  15.0000                                                     
+ Current cost            15.0000                                                     
  Resources                Memory  16.0M                                              
                           CPU       0.1                                              
  TTY                     False                                                       

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_disk_volumes_short[iso]_0.ref
@@ -1,22 +1,24 @@
-Job                  test-job                                                    
- Name                 test-job-name                                               
- Owner                test-user                                                   
- Cluster              default                                                     
- Description          test job description                                        
- Status               failed (ErrorReason)                                        
- Image                image:test-image:sometag                                    
- Command              test-command                                                
- Resources             Memory  16.0M                                              
-                       CPU       0.1                                              
- TTY                  False                                                       
- Disk volumes          /mnt/disk1  disk:disk1                           READONLY  
-                       /mnt/disk2  disk:/otheruser/disk2                          
-                       /mnt/disk3  disk://othercluster/otheruser/disk3            
- Http URL             http://local.host.test/                                     
- Http port            80                                                          
- Http authentication  True                                                        
- Created              2018-09-25T12:28:21.298672+00:00                            
- Started              2018-09-25T12:28:59.759433+00:00                            
- Finished             2018-09-25T12:28:59.759433+00:00                            
- Exit code            123                                                         
- Description          ErrorDesc
+Job                     test-job                                                    
+ Name                    test-job-name                                               
+ Owner                   test-user                                                   
+ Cluster                 default                                                     
+ Description             test job description                                        
+ Status                  failed (ErrorReason)                                        
+ Image                   image:test-image:sometag                                    
+ Command                 test-command                                                
+ Price (credits / hour)  15                                                          
+ Current cost            150                                                         
+ Resources                Memory  16.0M                                              
+                          CPU       0.1                                              
+ TTY                     False                                                       
+ Disk volumes             /mnt/disk1  disk:disk1                           READONLY  
+                          /mnt/disk2  disk:/otheruser/disk2                          
+                          /mnt/disk3  disk://othercluster/otheruser/disk3            
+ Http URL                http://local.host.test/                                     
+ Http port               80                                                          
+ Http authentication     True                                                        
+ Created                 2018-09-25T12:28:21.298672+00:00                            
+ Started                 2018-09-25T12:28:59.759433+00:00                            
+ Finished                2018-09-25T12:28:59.759433+00:00                            
+ Exit code               123                                                         
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Image                   test-image                 
  Entrypoint              /usr/bin/make              
  Command                 test                       
- Price (credits / hour)  15                         
- Current cost            150                        
+ Price (credits / hour)  15.0000                    
+ Current cost            15.0000                    
  Resources                Memory  16.0M             
                           CPU       0.1             
  TTY                     False                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Image                   test-image                       
  Entrypoint              /usr/bin/make                    
  Command                 test                             
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_entrypoint[iso]_0.ref
@@ -1,15 +1,17 @@
-Job                test-job                         
- Owner              test-user                        
- Cluster            default                          
- Description        test job description             
- Status             running (ContainerRunning)       
- Image              test-image                       
- Entrypoint         /usr/bin/make                    
- Command            test                             
- Resources           Memory  16.0M                   
-                     CPU       0.1                   
- TTY                False                            
- Internal Hostname  host.local                       
- Http URL           http://local.host.test/          
- Created            2018-09-25T12:28:21.298672+00:00 
- Started            2018-09-25T12:28:24.759433+00:00
+Job                     test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  running (ContainerRunning)       
+ Image                   test-image                       
+ Entrypoint              /usr/bin/make                    
+ Command                 test                             
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Internal Hostname       host.local                       
+ Http URL                http://local.host.test/          
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:24.759433+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)     
  Image                   image:test-image:sometag 
  Command                 test-command             
- Price (credits / hour)  15                       
- Current cost            150                      
+ Price (credits / hour)  15.0000                  
+ Current cost            15.0000                  
  Resources                Memory  16.0M           
                           CPU       0.1           
  TTY                     False                    

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[human]_0.ref
@@ -1,21 +1,23 @@
-Job                  test-job                 
- Name                 test-job-name            
- Owner                test-user                
- Cluster              default                  
- Description          test job description     
- Status               failed (ErrorReason)     
- Image                image:test-image:sometag 
- Command              test-command             
- Resources             Memory  16.0M           
-                       CPU       0.1           
- TTY                  False                    
- Http URL             http://local.host.test/  
- Http port            80                       
- Http authentication  True                     
- Environment           ENV_NAME_1  __value1__  
-                       ENV_NAME_2  **value2**  
- Created              Sep 25 2018 at 12:28     
- Started              Sep 25 2018 at 12:28     
- Finished             Sep 25 2018 at 12:28     
- Exit code            123                      
- Description          ErrorDesc
+Job                     test-job                 
+ Name                    test-job-name            
+ Owner                   test-user                
+ Cluster                 default                  
+ Description             test job description     
+ Status                  failed (ErrorReason)     
+ Image                   image:test-image:sometag 
+ Command                 test-command             
+ Price (credits / hour)  15                       
+ Current cost            150                      
+ Resources                Memory  16.0M           
+                          CPU       0.1           
+ TTY                     False                    
+ Http URL                http://local.host.test/  
+ Http port               80                       
+ Http authentication     True                     
+ Environment              ENV_NAME_1  __value1__  
+                          ENV_NAME_2  **value2**  
+ Created                 Sep 25 2018 at 12:28     
+ Started                 Sep 25 2018 at 12:28     
+ Finished                Sep 25 2018 at 12:28     
+ Exit code               123                      
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[iso]_0.ref
@@ -1,21 +1,23 @@
-Job                  test-job                         
- Name                 test-job-name                    
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                image:test-image:sometag         
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Environment           ENV_NAME_1  __value1__          
-                       ENV_NAME_2  **value2**          
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Name                    test-job-name                    
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   image:test-image:sometag         
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Environment              ENV_NAME_1  __value1__          
+                          ENV_NAME_2  **value2**          
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_environment[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   image:test-image:sometag         
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[human]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- Life span            1d2h3m4s                
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            123                     
- Description          ErrorDesc
+Job                     test-job                
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ Life span               1d2h3m4s                
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               123                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  Life span               1d2h3m4s                

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Life span               1d2h3m4s                         

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_with_value[iso]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                         
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                test-image                       
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- Life span            1d2h3m4s                         
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Life span               1d2h3m4s                         
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[human]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- Life span            no limit                
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            123                     
- Description          ErrorDesc
+Job                     test-job                
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ Life span               no limit                
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               123                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  Life span               no limit                

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_life_span_without_value[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Life span               no limit                         

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[human]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                
- Name                 test-job-name           
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            123                     
- Description          ErrorDesc
+Job                     test-job                
+ Name                    test-job-name           
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               123                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  TTY                     False                   

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_name[iso]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                         
- Name                 test-job-name                    
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                test-image                       
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Name                    test-job-name                    
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  running (ContainerRunning) 
  Image                   test-image                 
  Command                 test-command               
- Price (credits / hour)  15                         
- Current cost            150                        
+ Price (credits / hour)  15.0000                    
+ Current cost            15.0000                    
  Resources                Memory  16.0M             
                           CPU       0.1             
  TTY                     False                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[human]_0.ref
@@ -1,17 +1,16 @@
 Job                     test-job                   
+ Name                    test-job                   
  Owner                   test-user                  
  Cluster                 default                    
- Description             test job description       
+ Organisation            test-job-org-name          
  Status                  running (ContainerRunning) 
  Image                   test-image                 
- Entrypoint              /usr/bin/make              
- Command                 test                       
+ Command                 test-command               
  Price (credits / hour)  15                         
  Current cost            150                        
  Resources                Memory  16.0M             
                           CPU       0.1             
  TTY                     False                      
- Internal Hostname       host.local                 
  Http URL                http://local.host.test/    
  Created                 Sep 25 2018 at 12:28       
  Started                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[iso]_0.ref
@@ -1,21 +1,16 @@
 Job                     test-job                         
+ Name                    test-job                         
  Owner                   test-user                        
  Cluster                 default                          
- Description             test job description             
- Status                  failed (ErrorReason)             
+ Organisation            test-job-org-name                
+ Status                  running (ContainerRunning)       
  Image                   test-image                       
  Command                 test-command                     
  Price (credits / hour)  15                               
  Current cost            150                              
  Resources                Memory  16.0M                   
                           CPU       0.1                   
- Life span               no limit                         
  TTY                     False                            
  Http URL                http://local.host.test/          
- Http port               80                               
- Http authentication     True                             
  Created                 2018-09-25T12:28:21.298672+00:00 
- Started                 2018-09-25T12:28:59.759433+00:00 
- Finished                2018-09-25T12:28:59.759433+00:00 
- Exit code               123                              
- Description             ErrorDesc
+ Started                 2018-09-25T12:28:24.759433+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_org_name[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  running (ContainerRunning)       
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_partial_credits[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_partial_credits[human]_0.ref
@@ -1,0 +1,16 @@
+Job                     test-job                   
+ Name                    test-job                   
+ Owner                   test-user                  
+ Cluster                 default                    
+ Organisation            test-job-org-name          
+ Status                  running (ContainerRunning) 
+ Image                   test-image                 
+ Command                 test-command               
+ Price (credits / hour)  0.0010                     
+ Current cost            0.0010                     
+ Resources                Memory  16.0M             
+                          CPU       0.1             
+ TTY                     False                      
+ Http URL                http://local.host.test/    
+ Created                 Sep 25 2018 at 12:28       
+ Started                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_partial_credits[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_partial_credits[iso]_0.ref
@@ -1,0 +1,16 @@
+Job                     test-job                         
+ Name                    test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Organisation            test-job-org-name                
+ Status                  running (ContainerRunning)       
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  0.0010                           
+ Current cost            0.0010                           
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:24.759433+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Image                   test-image            
  Command                 test-command          
  Preset                  cpu-small             
- Price (credits / hour)  15                    
- Current cost            150                   
+ Price (credits / hour)  15.0000               
+ Current cost            15.0000               
  Resources                Memory  16.0M        
                           CPU       0.1        
  TTY                     False                 

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[human]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job              
- Owner        owner                 
- Cluster      default               
- Description  test job description  
- Status       pending               
- Image        test-image            
- Command      test-command          
- Preset       cpu-small             
- Resources     Memory  16.0M        
-               CPU       0.1        
- TTY          False                 
- Created      Sep 25 2018 at 12:28
+Job                     test-job              
+ Owner                   owner                 
+ Cluster                 default               
+ Description             test job description  
+ Status                  pending               
+ Image                   test-image            
+ Command                 test-command          
+ Preset                  cpu-small             
+ Price (credits / hour)  15                    
+ Current cost            150                   
+ Resources                Memory  16.0M        
+                          CPU       0.1        
+ TTY                     False                 
+ Created                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[iso]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job                         
- Owner        owner                            
- Cluster      default                          
- Description  test job description             
- Status       pending                          
- Image        test-image                       
- Command      test-command                     
- Preset       cpu-small                        
- Resources     Memory  16.0M                   
-               CPU       0.1                   
- TTY          False                            
- Created      2018-09-25T12:28:21.298672+00:00
+Job                     test-job                         
+ Owner                   owner                            
+ Cluster                 default                          
+ Description             test job description             
+ Status                  pending                          
+ Image                   test-image                       
+ Command                 test-command                     
+ Preset                  cpu-small                        
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Created                 2018-09-25T12:28:21.298672+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_preset_name[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Image                   test-image                       
  Command                 test-command                     
  Preset                  cpu-small                        
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  Restart policy          always                  

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[human]_0.ref
@@ -1,20 +1,22 @@
-Job                  test-job                
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- Restart policy       always                  
- Restarts             4                       
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            123                     
- Description          ErrorDesc
+Job                     test-job                
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ Restart policy          always                  
+ Restarts                4                       
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               123                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[iso]_0.ref
@@ -1,20 +1,22 @@
-Job                  test-job                         
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                test-image                       
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- Restart policy       always                           
- Restarts             4                                
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Restart policy          always                           
+ Restarts                4                                
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_restart_policy[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Restart policy          always                           

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                        
  Image                   image:test-image:sometag                                    
  Command                 test-command                                                
- Price (credits / hour)  15                                                          
- Current cost            150                                                         
+ Price (credits / hour)  15.0000                                                     
+ Current cost            15.0000                                                     
  Resources                Memory  16.0M                                              
                           CPU       0.1                                              
  TTY                     False                                                       

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[human]_0.ref
@@ -1,27 +1,29 @@
-Job                  test-job                                                    
- Name                 test-job-name                                               
- Owner                test-user                                                   
- Cluster              default                                                     
- Description          test job description                                        
- Status               failed (ErrorReason)                                        
- Image                image:test-image:sometag                                    
- Command              test-command                                                
- Resources             Memory  16.0M                                              
-                       CPU       0.1                                              
- TTY                  False                                                       
- Volumes               /mnt/rw  storage:rw                                        
- Secret files          /var/run/secret1  secret:secret1                           
-                       /var/run/secret2  secret:/otheruser/secret2                
-                       /var/run/secret3  secret://othercluster/otheruser/secret3  
- Http URL             http://local.host.test/                                     
- Http port            80                                                          
- Http authentication  True                                                        
- Environment           ENV_NAME_0  somevalue                                      
- Secret environment    ENV_NAME_1  secret:secret4                                 
-                       ENV_NAME_2  secret:/otheruser/secret5                      
-                       ENV_NAME_3  secret://othercluster/otheruser/secret6        
- Created              Sep 25 2018 at 12:28                                        
- Started              Sep 25 2018 at 12:28                                        
- Finished             Sep 25 2018 at 12:28                                        
- Exit code            123                                                         
- Description          ErrorDesc
+Job                     test-job                                                    
+ Name                    test-job-name                                               
+ Owner                   test-user                                                   
+ Cluster                 default                                                     
+ Description             test job description                                        
+ Status                  failed (ErrorReason)                                        
+ Image                   image:test-image:sometag                                    
+ Command                 test-command                                                
+ Price (credits / hour)  15                                                          
+ Current cost            150                                                         
+ Resources                Memory  16.0M                                              
+                          CPU       0.1                                              
+ TTY                     False                                                       
+ Volumes                  /mnt/rw  storage:rw                                        
+ Secret files             /var/run/secret1  secret:secret1                           
+                          /var/run/secret2  secret:/otheruser/secret2                
+                          /var/run/secret3  secret://othercluster/otheruser/secret3  
+ Http URL                http://local.host.test/                                     
+ Http port               80                                                          
+ Http authentication     True                                                        
+ Environment              ENV_NAME_0  somevalue                                      
+ Secret environment       ENV_NAME_1  secret:secret4                                 
+                          ENV_NAME_2  secret:/otheruser/secret5                      
+                          ENV_NAME_3  secret://othercluster/otheruser/secret6        
+ Created                 Sep 25 2018 at 12:28                                        
+ Started                 Sep 25 2018 at 12:28                                        
+ Finished                Sep 25 2018 at 12:28                                        
+ Exit code               123                                                         
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[iso]_0.ref
@@ -1,27 +1,29 @@
-Job                  test-job                                                    
- Name                 test-job-name                                               
- Owner                test-user                                                   
- Cluster              default                                                     
- Description          test job description                                        
- Status               failed (ErrorReason)                                        
- Image                image:test-image:sometag                                    
- Command              test-command                                                
- Resources             Memory  16.0M                                              
-                       CPU       0.1                                              
- TTY                  False                                                       
- Volumes               /mnt/rw  storage:rw                                        
- Secret files          /var/run/secret1  secret:secret1                           
-                       /var/run/secret2  secret:/otheruser/secret2                
-                       /var/run/secret3  secret://othercluster/otheruser/secret3  
- Http URL             http://local.host.test/                                     
- Http port            80                                                          
- Http authentication  True                                                        
- Environment           ENV_NAME_0  somevalue                                      
- Secret environment    ENV_NAME_1  secret:secret4                                 
-                       ENV_NAME_2  secret:/otheruser/secret5                      
-                       ENV_NAME_3  secret://othercluster/otheruser/secret6        
- Created              2018-09-25T12:28:21.298672+00:00                            
- Started              2018-09-25T12:28:59.759433+00:00                            
- Finished             2018-09-25T12:28:59.759433+00:00                            
- Exit code            123                                                         
- Description          ErrorDesc
+Job                     test-job                                                    
+ Name                    test-job-name                                               
+ Owner                   test-user                                                   
+ Cluster                 default                                                     
+ Description             test job description                                        
+ Status                  failed (ErrorReason)                                        
+ Image                   image:test-image:sometag                                    
+ Command                 test-command                                                
+ Price (credits / hour)  15                                                          
+ Current cost            150                                                         
+ Resources                Memory  16.0M                                              
+                          CPU       0.1                                              
+ TTY                     False                                                       
+ Volumes                  /mnt/rw  storage:rw                                        
+ Secret files             /var/run/secret1  secret:secret1                           
+                          /var/run/secret2  secret:/otheruser/secret2                
+                          /var/run/secret3  secret://othercluster/otheruser/secret3  
+ Http URL                http://local.host.test/                                     
+ Http port               80                                                          
+ Http authentication     True                                                        
+ Environment              ENV_NAME_0  somevalue                                      
+ Secret environment       ENV_NAME_1  secret:secret4                                 
+                          ENV_NAME_2  secret:/otheruser/secret5                      
+                          ENV_NAME_3  secret://othercluster/otheruser/secret6        
+ Created                 2018-09-25T12:28:21.298672+00:00                            
+ Started                 2018-09-25T12:28:59.759433+00:00                            
+ Finished                2018-09-25T12:28:59.759433+00:00                            
+ Exit code               123                                                         
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_secrets_short[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                        
  Image                   image:test-image:sometag                                    
  Command                 test-command                                                
- Price (credits / hour)  15                                                          
- Current cost            150                                                         
+ Price (credits / hour)  15.0000                                                     
+ Current cost            15.0000                                                     
  Resources                Memory  16.0M                                              
                           CPU       0.1                                              
  TTY                     False                                                       

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  TTY                     False                   

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[human]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                
- Tags                 tag1, tag2, tag3        
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            123                     
- Description          ErrorDesc
+Job                     test-job                
+ Tags                    tag1, tag2, tag3        
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               123                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags[iso]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                         
- Tags                 tag1, tag2, tag3                 
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                test-image                       
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Tags                    tag1, tag2, tag3                 
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                           
  Image                   test-image                                     
  Command                 test-command                                   
- Price (credits / hour)  15                                             
- Current cost            150                                            
+ Price (credits / hour)  15.0000                                        
+ Current cost            15.0000                                        
  Resources                Memory  16.0M                                 
                           CPU       0.1                                 
  TTY                     False                                          

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[human]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                                       
- Tags                 long-tag-1, long-tag-2, long-tag-3, long-tag-4 
- Owner                test-user                                      
- Cluster              default                                        
- Description          test job description                           
- Status               failed (ErrorReason)                           
- Image                test-image                                     
- Command              test-command                                   
- Resources             Memory  16.0M                                 
-                       CPU       0.1                                 
- TTY                  False                                          
- Http URL             http://local.host.test/                        
- Http port            80                                             
- Http authentication  True                                           
- Created              Sep 25 2018 at 12:28                           
- Started              Sep 25 2018 at 12:28                           
- Finished             Sep 25 2018 at 12:28                           
- Exit code            123                                            
- Description          ErrorDesc
+Job                     test-job                                       
+ Tags                    long-tag-1, long-tag-2, long-tag-3, long-tag-4 
+ Owner                   test-user                                      
+ Cluster                 default                                        
+ Description             test job description                           
+ Status                  failed (ErrorReason)                           
+ Image                   test-image                                     
+ Command                 test-command                                   
+ Price (credits / hour)  15                                             
+ Current cost            150                                            
+ Resources                Memory  16.0M                                 
+                          CPU       0.1                                 
+ TTY                     False                                          
+ Http URL                http://local.host.test/                        
+ Http port               80                                             
+ Http authentication     True                                           
+ Created                 Sep 25 2018 at 12:28                           
+ Started                 Sep 25 2018 at 12:28                           
+ Finished                Sep 25 2018 at 12:28                           
+ Exit code               123                                            
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                           
  Image                   test-image                                     
  Command                 test-command                                   
- Price (credits / hour)  15                                             
- Current cost            150                                            
+ Price (credits / hour)  15.0000                                        
+ Current cost            15.0000                                        
  Resources                Memory  16.0M                                 
                           CPU       0.1                                 
  TTY                     False                                          

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_tags_wrap_tags[iso]_0.ref
@@ -1,19 +1,21 @@
-Job                  test-job                                       
- Tags                 long-tag-1, long-tag-2, long-tag-3, long-tag-4 
- Owner                test-user                                      
- Cluster              default                                        
- Description          test job description                           
- Status               failed (ErrorReason)                           
- Image                test-image                                     
- Command              test-command                                   
- Resources             Memory  16.0M                                 
-                       CPU       0.1                                 
- TTY                  False                                          
- Http URL             http://local.host.test/                        
- Http port            80                                             
- Http authentication  True                                           
- Created              2018-09-25T12:28:21.298672+00:00               
- Started              2018-09-25T12:28:59.759433+00:00               
- Finished             2018-09-25T12:28:59.759433+00:00               
- Exit code            123                                            
- Description          ErrorDesc
+Job                     test-job                                       
+ Tags                    long-tag-1, long-tag-2, long-tag-3, long-tag-4 
+ Owner                   test-user                                      
+ Cluster                 default                                        
+ Description             test job description                           
+ Status                  failed (ErrorReason)                           
+ Image                   test-image                                     
+ Command                 test-command                                   
+ Price (credits / hour)  15                                             
+ Current cost            150                                            
+ Resources                Memory  16.0M                                 
+                          CPU       0.1                                 
+ TTY                     False                                          
+ Http URL                http://local.host.test/                        
+ Http port               80                                             
+ Http authentication     True                                           
+ Created                 2018-09-25T12:28:21.298672+00:00               
+ Started                 2018-09-25T12:28:59.759433+00:00               
+ Finished                2018-09-25T12:28:59.759433+00:00               
+ Exit code               123                                            
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[human]_0.ref
@@ -1,21 +1,23 @@
-Job                  test-job                                                 
- Name                 test-job-name                                            
- Owner                test-user                                                
- Cluster              default                                                  
- Description          test job description                                     
- Status               failed (ErrorReason)                                     
- Image                image://test-cluster/test-user/test-image:sometag        
- Command              test-command                                             
- Resources             Memory  16.0M                                           
-                       CPU       0.1                                           
- TTY                  False                                                    
- Volumes               /mnt/ro  storage://test-cluster/otheruser/ro  READONLY  
-                       /mnt/rw  storage://test-cluster/test-user/rw            
- Http URL             http://local.host.test/                                  
- Http port            80                                                       
- Http authentication  True                                                     
- Created              Sep 25 2018 at 12:28                                     
- Started              Sep 25 2018 at 12:28                                     
- Finished             Sep 25 2018 at 12:28                                     
- Exit code            123                                                      
- Description          ErrorDesc
+Job                     test-job                                                 
+ Name                    test-job-name                                            
+ Owner                   test-user                                                
+ Cluster                 default                                                  
+ Description             test job description                                     
+ Status                  failed (ErrorReason)                                     
+ Image                   image://test-cluster/test-user/test-image:sometag        
+ Command                 test-command                                             
+ Price (credits / hour)  15                                                       
+ Current cost            150                                                      
+ Resources                Memory  16.0M                                           
+                          CPU       0.1                                           
+ TTY                     False                                                    
+ Volumes                  /mnt/ro  storage://test-cluster/otheruser/ro  READONLY  
+                          /mnt/rw  storage://test-cluster/test-user/rw            
+ Http URL                http://local.host.test/                                  
+ Http port               80                                                       
+ Http authentication     True                                                     
+ Created                 Sep 25 2018 at 12:28                                     
+ Started                 Sep 25 2018 at 12:28                                     
+ Finished                Sep 25 2018 at 12:28                                     
+ Exit code               123                                                      
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                     
  Image                   image://test-cluster/test-user/test-image:sometag        
  Command                 test-command                                             
- Price (credits / hour)  15                                                       
- Current cost            150                                                      
+ Price (credits / hour)  15.0000                                                  
+ Current cost            15.0000                                                  
  Resources                Memory  16.0M                                           
                           CPU       0.1                                           
  TTY                     False                                                    

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                     
  Image                   image://test-cluster/test-user/test-image:sometag        
  Command                 test-command                                             
- Price (credits / hour)  15                                                       
- Current cost            150                                                      
+ Price (credits / hour)  15.0000                                                  
+ Current cost            15.0000                                                  
  Resources                Memory  16.0M                                           
                           CPU       0.1                                           
  TTY                     False                                                    

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_long[iso]_0.ref
@@ -1,21 +1,23 @@
-Job                  test-job                                                 
- Name                 test-job-name                                            
- Owner                test-user                                                
- Cluster              default                                                  
- Description          test job description                                     
- Status               failed (ErrorReason)                                     
- Image                image://test-cluster/test-user/test-image:sometag        
- Command              test-command                                             
- Resources             Memory  16.0M                                           
-                       CPU       0.1                                           
- TTY                  False                                                    
- Volumes               /mnt/ro  storage://test-cluster/otheruser/ro  READONLY  
-                       /mnt/rw  storage://test-cluster/test-user/rw            
- Http URL             http://local.host.test/                                  
- Http port            80                                                       
- Http authentication  True                                                     
- Created              2018-09-25T12:28:21.298672+00:00                         
- Started              2018-09-25T12:28:59.759433+00:00                         
- Finished             2018-09-25T12:28:59.759433+00:00                         
- Exit code            123                                                      
- Description          ErrorDesc
+Job                     test-job                                                 
+ Name                    test-job-name                                            
+ Owner                   test-user                                                
+ Cluster                 default                                                  
+ Description             test job description                                     
+ Status                  failed (ErrorReason)                                     
+ Image                   image://test-cluster/test-user/test-image:sometag        
+ Command                 test-command                                             
+ Price (credits / hour)  15                                                       
+ Current cost            150                                                      
+ Resources                Memory  16.0M                                           
+                          CPU       0.1                                           
+ TTY                     False                                                    
+ Volumes                  /mnt/ro  storage://test-cluster/otheruser/ro  READONLY  
+                          /mnt/rw  storage://test-cluster/test-user/rw            
+ Http URL                http://local.host.test/                                  
+ Http port               80                                                       
+ Http authentication     True                                                     
+ Created                 2018-09-25T12:28:21.298672+00:00                         
+ Started                 2018-09-25T12:28:59.759433+00:00                         
+ Finished                2018-09-25T12:28:59.759433+00:00                         
+ Exit code               123                                                      
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[human]_0.ref
@@ -1,22 +1,24 @@
-Job                  test-job                                                   
- Name                 test-job-name                                              
- Owner                test-user                                                  
- Cluster              default                                                    
- Description          test job description                                       
- Status               failed (ErrorReason)                                       
- Image                image:test-image:sometag                                   
- Command              test-command                                               
- Resources             Memory  16.0M                                             
-                       CPU       0.1                                             
- TTY                  False                                                      
- Volumes               /mnt/_ro_  storage:/otheruser/_ro_              READONLY  
-                       /mnt/rw    storage:rw                                     
-                       /mnt/ro    storage://othercluster/otheruser/ro  READONLY  
- Http URL             http://local.host.test/                                    
- Http port            80                                                         
- Http authentication  True                                                       
- Created              Sep 25 2018 at 12:28                                       
- Started              Sep 25 2018 at 12:28                                       
- Finished             Sep 25 2018 at 12:28                                       
- Exit code            123                                                        
- Description          ErrorDesc
+Job                     test-job                                                   
+ Name                    test-job-name                                              
+ Owner                   test-user                                                  
+ Cluster                 default                                                    
+ Description             test job description                                       
+ Status                  failed (ErrorReason)                                       
+ Image                   image:test-image:sometag                                   
+ Command                 test-command                                               
+ Price (credits / hour)  15                                                         
+ Current cost            150                                                        
+ Resources                Memory  16.0M                                             
+                          CPU       0.1                                             
+ TTY                     False                                                      
+ Volumes                  /mnt/_ro_  storage:/otheruser/_ro_              READONLY  
+                          /mnt/rw    storage:rw                                     
+                          /mnt/ro    storage://othercluster/otheruser/ro  READONLY  
+ Http URL                http://local.host.test/                                    
+ Http port               80                                                         
+ Http authentication     True                                                       
+ Created                 Sep 25 2018 at 12:28                                       
+ Started                 Sep 25 2018 at 12:28                                       
+ Finished                Sep 25 2018 at 12:28                                       
+ Exit code               123                                                        
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[human]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                       
  Image                   image:test-image:sometag                                   
  Command                 test-command                                               
- Price (credits / hour)  15                                                         
- Current cost            150                                                        
+ Price (credits / hour)  15.0000                                                    
+ Current cost            15.0000                                                    
  Resources                Memory  16.0M                                             
                           CPU       0.1                                             
  TTY                     False                                                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[iso]_0.ref
@@ -1,22 +1,24 @@
-Job                  test-job                                                   
- Name                 test-job-name                                              
- Owner                test-user                                                  
- Cluster              default                                                    
- Description          test job description                                       
- Status               failed (ErrorReason)                                       
- Image                image:test-image:sometag                                   
- Command              test-command                                               
- Resources             Memory  16.0M                                             
-                       CPU       0.1                                             
- TTY                  False                                                      
- Volumes               /mnt/_ro_  storage:/otheruser/_ro_              READONLY  
-                       /mnt/rw    storage:rw                                     
-                       /mnt/ro    storage://othercluster/otheruser/ro  READONLY  
- Http URL             http://local.host.test/                                    
- Http port            80                                                         
- Http authentication  True                                                       
- Created              2018-09-25T12:28:21.298672+00:00                           
- Started              2018-09-25T12:28:59.759433+00:00                           
- Finished             2018-09-25T12:28:59.759433+00:00                           
- Exit code            123                                                        
- Description          ErrorDesc
+Job                     test-job                                                   
+ Name                    test-job-name                                              
+ Owner                   test-user                                                  
+ Cluster                 default                                                    
+ Description             test job description                                       
+ Status                  failed (ErrorReason)                                       
+ Image                   image:test-image:sometag                                   
+ Command                 test-command                                               
+ Price (credits / hour)  15                                                         
+ Current cost            150                                                        
+ Resources                Memory  16.0M                                             
+                          CPU       0.1                                             
+ TTY                     False                                                      
+ Volumes                  /mnt/_ro_  storage:/otheruser/_ro_              READONLY  
+                          /mnt/rw    storage:rw                                     
+                          /mnt/ro    storage://othercluster/otheruser/ro  READONLY  
+ Http URL                http://local.host.test/                                    
+ Http port               80                                                         
+ Http authentication     True                                                       
+ Created                 2018-09-25T12:28:21.298672+00:00                           
+ Started                 2018-09-25T12:28:59.759433+00:00                           
+ Finished                2018-09-25T12:28:59.759433+00:00                           
+ Exit code               123                                                        
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_volumes_short[iso]_0.ref
@@ -6,8 +6,8 @@ Job                     test-job
  Status                  failed (ErrorReason)                                       
  Image                   image:test-image:sometag                                   
  Command                 test-command                                               
- Price (credits / hour)  15                                                         
- Current cost            150                                                        
+ Price (credits / hour)  15.0000                                                    
+ Current cost            15.0000                                                    
  Resources                Memory  16.0M                                             
                           CPU       0.1                                             
  TTY                     False                                                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[human]_0.ref
@@ -1,20 +1,22 @@
-Job                  test-job                 
- Name                 test-job-name            
- Owner                test-user                
- Cluster              default                  
- Description          test job description     
- Status               failed (ErrorReason)     
- Image                image:test-image:sometag 
- Command              test-command             
- Working dir          /working/dir             
- Resources             Memory  16.0M           
-                       CPU       0.1           
- TTY                  False                    
- Http URL             http://local.host.test/  
- Http port            80                       
- Http authentication  True                     
- Created              Sep 25 2018 at 12:28     
- Started              Sep 25 2018 at 12:28     
- Finished             Sep 25 2018 at 12:28     
- Exit code            123                      
- Description          ErrorDesc
+Job                     test-job                 
+ Name                    test-job-name            
+ Owner                   test-user                
+ Cluster                 default                  
+ Description             test job description     
+ Status                  failed (ErrorReason)     
+ Image                   image:test-image:sometag 
+ Command                 test-command             
+ Working dir             /working/dir             
+ Price (credits / hour)  15                       
+ Current cost            150                      
+ Resources                Memory  16.0M           
+                          CPU       0.1           
+ TTY                     False                    
+ Http URL                http://local.host.test/  
+ Http port               80                       
+ Http authentication     True                     
+ Created                 Sep 25 2018 at 12:28     
+ Started                 Sep 25 2018 at 12:28     
+ Finished                Sep 25 2018 at 12:28     
+ Exit code               123                      
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[human]_0.ref
@@ -7,8 +7,8 @@ Job                     test-job
  Image                   image:test-image:sometag 
  Command                 test-command             
  Working dir             /working/dir             
- Price (credits / hour)  15                       
- Current cost            150                      
+ Price (credits / hour)  15.0000                  
+ Current cost            15.0000                  
  Resources                Memory  16.0M           
                           CPU       0.1           
  TTY                     False                    

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[iso]_0.ref
@@ -1,20 +1,22 @@
-Job                  test-job                         
- Name                 test-job-name                    
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                image:test-image:sometag         
- Command              test-command                     
- Working dir          /working/dir                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            123                              
- Description          ErrorDesc
+Job                     test-job                         
+ Name                    test-job-name                    
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   image:test-image:sometag         
+ Command                 test-command                     
+ Working dir             /working/dir                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               123                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_job_with_working_dir[iso]_0.ref
@@ -7,8 +7,8 @@ Job                     test-job
  Image                   image:test-image:sometag         
  Command                 test-command                     
  Working dir             /working/dir                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[human]_0.ref
@@ -1,18 +1,20 @@
-Job                  test-job                
- Owner                test-user               
- Cluster              default                 
- Description          test job description    
- Status               failed (ErrorReason)    
- Image                test-image              
- Command              test-command            
- Resources             Memory  16.0M          
-                       CPU       0.1          
- TTY                  False                   
- Http URL             http://local.host.test/ 
- Http port            80                      
- Http authentication  True                    
- Created              Sep 25 2018 at 12:28    
- Started              Sep 25 2018 at 12:28    
- Finished             Sep 25 2018 at 12:28    
- Exit code            321                     
- Description          ErrorDesc
+Job                     test-job                
+ Owner                   test-user               
+ Cluster                 default                 
+ Description             test job description    
+ Status                  failed (ErrorReason)    
+ Image                   test-image              
+ Command                 test-command            
+ Price (credits / hour)  15                      
+ Current cost            150                     
+ Resources                Memory  16.0M          
+                          CPU       0.1          
+ TTY                     False                   
+ Http URL                http://local.host.test/ 
+ Http port               80                      
+ Http authentication     True                    
+ Created                 Sep 25 2018 at 12:28    
+ Started                 Sep 25 2018 at 12:28    
+ Finished                Sep 25 2018 at 12:28    
+ Exit code               321                     
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)    
  Image                   test-image              
  Command                 test-command            
- Price (credits / hour)  15                      
- Current cost            150                     
+ Price (credits / hour)  15.0000                 
+ Current cost            15.0000                 
  Resources                Memory  16.0M          
                           CPU       0.1          
  TTY                     False                   

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  failed (ErrorReason)             
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job[iso]_0.ref
@@ -1,18 +1,20 @@
-Job                  test-job                         
- Owner                test-user                        
- Cluster              default                          
- Description          test job description             
- Status               failed (ErrorReason)             
- Image                test-image                       
- Command              test-command                     
- Resources             Memory  16.0M                   
-                       CPU       0.1                   
- TTY                  False                            
- Http URL             http://local.host.test/          
- Http port            80                               
- Http authentication  True                             
- Created              2018-09-25T12:28:21.298672+00:00 
- Started              2018-09-25T12:28:59.759433+00:00 
- Finished             2018-09-25T12:28:59.759433+00:00 
- Exit code            321                              
- Description          ErrorDesc
+Job                     test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  failed (ErrorReason)             
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Http URL                http://local.host.test/          
+ Http port               80                               
+ Http authentication     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:59.759433+00:00 
+ Finished                2018-09-25T12:28:59.759433+00:00 
+ Exit code               321                              
+ Description             ErrorDesc

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[human]_0.ref
@@ -1,11 +1,13 @@
-Job          test-job                    
- Owner        owner                       
- Cluster      default                     
- Status       pending (ContainerCreating) 
- Image        test-image                  
- Command      test-command                
- Resources     Memory  16.0M              
-               CPU       0.1              
- Round Robin  True                        
- TTY          False                       
- Created      Sep 25 2018 at 12:28
+Job                     test-job                    
+ Owner                   owner                       
+ Cluster                 default                     
+ Status                  pending (ContainerCreating) 
+ Image                   test-image                  
+ Command                 test-command                
+ Price (credits / hour)  15                          
+ Current cost            150                         
+ Resources                Memory  16.0M              
+                          CPU       0.1              
+ Round Robin             True                        
+ TTY                     False                       
+ Created                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[human]_0.ref
@@ -4,8 +4,8 @@ Job                     test-job
  Status                  pending (ContainerCreating) 
  Image                   test-image                  
  Command                 test-command                
- Price (credits / hour)  15                          
- Current cost            150                         
+ Price (credits / hour)  15.0000                     
+ Current cost            15.0000                     
  Resources                Memory  16.0M              
                           CPU       0.1              
  Round Robin             True                        

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[iso]_0.ref
@@ -1,11 +1,13 @@
-Job          test-job                         
- Owner        owner                            
- Cluster      default                          
- Status       pending (ContainerCreating)      
- Image        test-image                       
- Command      test-command                     
- Resources     Memory  16.0M                   
-               CPU       0.1                   
- Round Robin  True                             
- TTY          False                            
- Created      2018-09-25T12:28:21.298672+00:00
+Job                     test-job                         
+ Owner                   owner                            
+ Cluster                 default                          
+ Status                  pending (ContainerCreating)      
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Round Robin             True                             
+ TTY                     False                            
+ Created                 2018-09-25T12:28:21.298672+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_description[iso]_0.ref
@@ -4,8 +4,8 @@ Job                     test-job
  Status                  pending (ContainerCreating)      
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Round Robin             True                             

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[human]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job              
- Owner        owner                 
- Cluster      default               
- Description  test job description  
- Status       pending               
- Image        test-image            
- Command      test-command          
- Resources     Memory  16.0M        
-               CPU       0.1        
- Round Robin  True                  
- TTY          False                 
- Created      Sep 25 2018 at 12:28
+Job                     test-job              
+ Owner                   owner                 
+ Cluster                 default               
+ Description             test job description  
+ Status                  pending               
+ Image                   test-image            
+ Command                 test-command          
+ Price (credits / hour)  15                    
+ Current cost            150                   
+ Resources                Memory  16.0M        
+                          CPU       0.1        
+ Round Robin             True                  
+ TTY                     False                 
+ Created                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending               
  Image                   test-image            
  Command                 test-command          
- Price (credits / hour)  15                    
- Current cost            150                   
+ Price (credits / hour)  15.0000               
+ Current cost            15.0000               
  Resources                Memory  16.0M        
                           CPU       0.1        
  Round Robin             True                  

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending                          
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Round Robin             True                             

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_no_reason[iso]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job                         
- Owner        owner                            
- Cluster      default                          
- Description  test job description             
- Status       pending                          
- Image        test-image                       
- Command      test-command                     
- Resources     Memory  16.0M                   
-               CPU       0.1                   
- Round Robin  True                             
- TTY          False                            
- Created      2018-09-25T12:28:21.298672+00:00
+Job                     test-job                         
+ Owner                   owner                            
+ Cluster                 default                          
+ Description             test job description             
+ Status                  pending                          
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Round Robin             True                             
+ TTY                     False                            
+ Created                 2018-09-25T12:28:21.298672+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[human]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job                    
- Owner        owner                       
- Cluster      default                     
- Description  test job description        
- Status       pending (ContainerCreating) 
- Image        test-image                  
- Command      test-command                
- Resources     Memory  16.0M              
-               CPU       0.1              
- Round Robin  True                        
- TTY          True                        
- Created      Sep 25 2018 at 12:28
+Job                     test-job                    
+ Owner                   owner                       
+ Cluster                 default                     
+ Description             test job description        
+ Status                  pending (ContainerCreating) 
+ Image                   test-image                  
+ Command                 test-command                
+ Price (credits / hour)  15                          
+ Current cost            150                         
+ Resources                Memory  16.0M              
+                          CPU       0.1              
+ Round Robin             True                        
+ TTY                     True                        
+ Created                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending (ContainerCreating) 
  Image                   test-image                  
  Command                 test-command                
- Price (credits / hour)  15                          
- Current cost            150                         
+ Price (credits / hour)  15.0000                     
+ Current cost            15.0000                     
  Resources                Memory  16.0M              
                           CPU       0.1              
  Round Robin             True                        

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[iso]_0.ref
@@ -1,12 +1,14 @@
-Job          test-job                         
- Owner        owner                            
- Cluster      default                          
- Description  test job description             
- Status       pending (ContainerCreating)      
- Image        test-image                       
- Command      test-command                     
- Resources     Memory  16.0M                   
-               CPU       0.1                   
- Round Robin  True                             
- TTY          True                             
- Created      2018-09-25T12:28:21.298672+00:00
+Job                     test-job                         
+ Owner                   owner                            
+ Cluster                 default                          
+ Description             test job description             
+ Status                  pending (ContainerCreating)      
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ Round Robin             True                             
+ TTY                     True                             
+ Created                 2018-09-25T12:28:21.298672+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_pending_job_with_reason[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  pending (ContainerCreating)      
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  Round Robin             True                             

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  running (ContainerRunning) 
  Image                   test-image                 
  Command                 test-command               
- Price (credits / hour)  15                         
- Current cost            150                        
+ Price (credits / hour)  15.0000                    
+ Current cost            15.0000                    
  Resources                Memory  16.0M             
                           CPU       0.1             
  TTY                     False                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[human]_0.ref
@@ -1,14 +1,16 @@
-Job                test-job                   
- Owner              test-user                  
- Cluster            default                    
- Description        test job description       
- Status             running (ContainerRunning) 
- Image              test-image                 
- Command            test-command               
- Resources           Memory  16.0M             
-                     CPU       0.1             
- TTY                False                      
- Internal Hostname  host.local                 
- Http URL           http://local.host.test/    
- Created            Sep 25 2018 at 12:28       
- Started            Sep 25 2018 at 12:28
+Job                     test-job                   
+ Owner                   test-user                  
+ Cluster                 default                    
+ Description             test job description       
+ Status                  running (ContainerRunning) 
+ Image                   test-image                 
+ Command                 test-command               
+ Price (credits / hour)  15                         
+ Current cost            150                        
+ Resources                Memory  16.0M             
+                          CPU       0.1             
+ TTY                     False                      
+ Internal Hostname       host.local                 
+ Http URL                http://local.host.test/    
+ Created                 Sep 25 2018 at 12:28       
+ Started                 Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  running (ContainerRunning)       
  Image                   test-image                       
  Command                 test-command                     
- Price (credits / hour)  15                               
- Current cost            150                              
+ Price (credits / hour)  15.0000                          
+ Current cost            15.0000                          
  Resources                Memory  16.0M                   
                           CPU       0.1                   
  TTY                     False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job[iso]_0.ref
@@ -1,14 +1,16 @@
-Job                test-job                         
- Owner              test-user                        
- Cluster            default                          
- Description        test job description             
- Status             running (ContainerRunning)       
- Image              test-image                       
- Command            test-command                     
- Resources           Memory  16.0M                   
-                     CPU       0.1                   
- TTY                False                            
- Internal Hostname  host.local                       
- Http URL           http://local.host.test/          
- Created            2018-09-25T12:28:21.298672+00:00 
- Started            2018-09-25T12:28:24.759433+00:00
+Job                     test-job                         
+ Owner                   test-user                        
+ Cluster                 default                          
+ Description             test job description             
+ Status                  running (ContainerRunning)       
+ Image                   test-image                       
+ Command                 test-command                     
+ Price (credits / hour)  15                               
+ Current cost            150                              
+ Resources                Memory  16.0M                   
+                          CPU       0.1                   
+ TTY                     False                            
+ Internal Hostname       host.local                       
+ Http URL                http://local.host.test/          
+ Created                 2018-09-25T12:28:21.298672+00:00 
+ Started                 2018-09-25T12:28:24.759433+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[human]_0.ref
@@ -1,19 +1,21 @@
-Job                 test-job                                             
- Owner               test-user                                            
- Cluster             default                                              
- Description         test job description                                 
- Status              running (ContainerRunning)                           
- Image               test-image                                           
- Command             test-command                                         
- Resources            Memory  16.0M                                       
-                      CPU       0.1                                       
- TTY                 False                                                
- Internal Hostname   host.local                                           
- Http URL            http://local.host.test/                              
- Created             Sep 25 2018 at 12:28                                 
- Started             Sep 25 2018 at 12:28                                 
- Status transitions   Status                       Time                   
-                      pending (Creating)           Sep 25 2018 at 12:28   
-                      pending (Scheduling)         Sep 25 2018 at 12:28   
-                      pending (ContainerCreating)  Sep 25 2018 at 12:28   
-                      running                      Sep 25 2018 at 12:28
+Job                     test-job                                             
+ Owner                   test-user                                            
+ Cluster                 default                                              
+ Description             test job description                                 
+ Status                  running (ContainerRunning)                           
+ Image                   test-image                                           
+ Command                 test-command                                         
+ Price (credits / hour)  15                                                   
+ Current cost            150                                                  
+ Resources                Memory  16.0M                                       
+                          CPU       0.1                                       
+ TTY                     False                                                
+ Internal Hostname       host.local                                           
+ Http URL                http://local.host.test/                              
+ Created                 Sep 25 2018 at 12:28                                 
+ Started                 Sep 25 2018 at 12:28                                 
+ Status transitions       Status                       Time                   
+                          pending (Creating)           Sep 25 2018 at 12:28   
+                          pending (Scheduling)         Sep 25 2018 at 12:28   
+                          pending (ContainerCreating)  Sep 25 2018 at 12:28   
+                          running                      Sep 25 2018 at 12:28

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[human]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  running (ContainerRunning)                           
  Image                   test-image                                           
  Command                 test-command                                         
- Price (credits / hour)  15                                                   
- Current cost            150                                                  
+ Price (credits / hour)  15.0000                                              
+ Current cost            15.0000                                              
  Resources                Memory  16.0M                                       
                           CPU       0.1                                       
  TTY                     False                                                

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[iso]_0.ref
@@ -1,19 +1,21 @@
-Job                 test-job                                                        
- Owner               test-user                                                       
- Cluster             default                                                         
- Description         test job description                                            
- Status              running (ContainerRunning)                                      
- Image               test-image                                                      
- Command             test-command                                                    
- Resources            Memory  16.0M                                                  
-                      CPU       0.1                                                  
- TTY                 False                                                           
- Internal Hostname   host.local                                                      
- Http URL            http://local.host.test/                                         
- Created             2018-09-25T12:28:21.298672+00:00                                
- Started             2018-09-25T12:28:24.759433+00:00                                
- Status transitions   Status                       Time                              
-                      pending (Creating)           2018-09-25T12:28:21.298672+00:00  
-                      pending (Scheduling)         2018-09-25T12:28:22.298672+00:00  
-                      pending (ContainerCreating)  2018-09-25T12:28:23.298672+00:00  
-                      running                      2018-09-25T12:28:24.759433+00:00
+Job                     test-job                                                        
+ Owner                   test-user                                                       
+ Cluster                 default                                                         
+ Description             test job description                                            
+ Status                  running (ContainerRunning)                                      
+ Image                   test-image                                                      
+ Command                 test-command                                                    
+ Price (credits / hour)  15                                                              
+ Current cost            150                                                             
+ Resources                Memory  16.0M                                                  
+                          CPU       0.1                                                  
+ TTY                     False                                                           
+ Internal Hostname       host.local                                                      
+ Http URL                http://local.host.test/                                         
+ Created                 2018-09-25T12:28:21.298672+00:00                                
+ Started                 2018-09-25T12:28:24.759433+00:00                                
+ Status transitions       Status                       Time                              
+                          pending (Creating)           2018-09-25T12:28:21.298672+00:00  
+                          pending (Scheduling)         2018-09-25T12:28:22.298672+00:00  
+                          pending (ContainerCreating)  2018-09-25T12:28:23.298672+00:00  
+                          running                      2018-09-25T12:28:24.759433+00:00

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_job_with_status_items[iso]_0.ref
@@ -5,8 +5,8 @@ Job                     test-job
  Status                  running (ContainerRunning)                                      
  Image                   test-image                                                      
  Command                 test-command                                                    
- Price (credits / hour)  15                                                              
- Current cost            150                                                             
+ Price (credits / hour)  15.0000                                                         
+ Current cost            15.0000                                                         
  Resources                Memory  16.0M                                                  
                           CPU       0.1                                                  
  TTY                     False                                                           

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[human]_0.ref
@@ -6,6 +6,8 @@ Job                      test-job
  Status                   running (ContainerRunning) 
  Image                    test-image                 
  Command                  test-command               
+ Price (credits / hour)   15                         
+ Current cost             150                        
  Resources                 Memory  16.0M             
                            CPU       0.1             
  TTY                      False                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[human]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[human]_0.ref
@@ -6,8 +6,8 @@ Job                      test-job
  Status                   running (ContainerRunning) 
  Image                    test-image                 
  Command                  test-command               
- Price (credits / hour)   15                         
- Current cost             150                        
+ Price (credits / hour)   15.0000                    
+ Current cost             15.0000                    
  Resources                 Memory  16.0M             
                            CPU       0.1             
  TTY                      False                      

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[iso]_0.ref
@@ -6,6 +6,8 @@ Job                      test-job
  Status                   running (ContainerRunning)       
  Image                    test-image                       
  Command                  test-command                     
+ Price (credits / hour)   15                               
+ Current cost             150                              
  Resources                 Memory  16.0M                   
                            CPU       0.1                   
  TTY                      False                            

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[iso]_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobOutputFormatter.test_running_named_job[iso]_0.ref
@@ -6,8 +6,8 @@ Job                      test-job
  Status                   running (ContainerRunning)       
  Image                    test-image                       
  Command                  test-command                     
- Price (credits / hour)   15                               
- Current cost             150                              
+ Price (credits / hour)   15.0000                          
+ Current cost             15.0000                          
  Resources                 Memory  16.0M                   
                            CPU       0.1                   
  TTY                      False                            

--- a/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
+++ b/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
@@ -111,6 +111,8 @@ def job_descr_no_name() -> JobDescription:
         ),
         scheduler_enabled=True,
         pass_config=True,
+        total_price_credits="150",
+        price_credits_per_hour="15",
     )
 
 
@@ -137,6 +139,8 @@ def job_descr() -> JobDescription:
         ),
         scheduler_enabled=True,
         pass_config=True,
+        total_price_credits="150",
+        price_credits_per_hour="15",
     )
 
 
@@ -149,6 +153,8 @@ class TestJobStartProgress:
         name: Optional[str] = None,
         life_span: Optional[float] = None,
         description: str = "ErrorDesc",
+        total_price_credits: str = "150",
+        price_credits_per_hour: str = "15",
     ) -> JobDescription:
         return JobDescription(
             name=name,
@@ -183,6 +189,8 @@ class TestJobStartProgress:
             scheduler_enabled=False,
             pass_config=True,
             life_span=life_span,
+            total_price_credits=total_price_credits,
+            price_credits_per_hour=price_credits_per_hour,
         )
 
     def test_quiet(self, rich_cmp: Any, new_console: _NewConsole) -> None:
@@ -296,6 +304,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -334,6 +344,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -372,6 +384,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -410,6 +424,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=1.0 * ((60 * 60 * 24 * 1) + (60 * 60 * 2) + (60 * 3) + 4),
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -448,6 +464,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=0.0,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -487,6 +505,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             restart_policy=JobRestartPolicy.ALWAYS,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -524,6 +544,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -558,6 +580,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -593,6 +617,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -627,6 +653,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -663,6 +691,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -720,6 +750,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -758,6 +790,8 @@ class TestJobOutputFormatter:
             pass_config=True,
             internal_hostname="host.local",
             internal_hostname_named="test-job--test-owner.local",
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -795,6 +829,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -840,6 +876,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -901,6 +939,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -957,6 +997,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         rich_cmp(
@@ -1027,6 +1069,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1088,6 +1132,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1133,6 +1179,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1168,6 +1216,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1203,6 +1253,46 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
+            total_price_credits="150",
+            price_credits_per_hour="15",
+        )
+
+        uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
+        rich_cmp(
+            JobStatusFormatter(
+                uri_formatter=uri_fmtr, datetime_formatter=datetime_formatter
+            )(description)
+        )
+
+    def test_job_with_org_name(
+        self, rich_cmp: Any, datetime_formatter: DatetimeFormatter
+    ) -> None:
+        description = JobDescription(
+            status=JobStatus.RUNNING,
+            owner="test-user",
+            name="test-job",
+            cluster_name="default",
+            org_name="test-job-org-name",
+            id="test-job",
+            uri=URL("job://default/test-user/test-job"),
+            history=JobStatusHistory(
+                status=JobStatus.RUNNING,
+                reason="ContainerRunning",
+                description="",
+                created_at=isoparse("2018-09-25T12:28:21.298672+00:00"),
+                started_at=isoparse("2018-09-25T12:28:24.759433+00:00"),
+                finished_at=None,
+            ),
+            http_url=URL("http://local.host.test/"),
+            container=Container(
+                command="test-command",
+                image=RemoteImage.new_external_image(name="test-image"),
+                resources=Resources(16, 0.1, 0, None, False, None, None),
+            ),
+            scheduler_enabled=False,
+            pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1450,6 +1540,8 @@ class TestSimpleJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             ),
             JobDescription(
                 status=JobStatus.PENDING,
@@ -1472,6 +1564,8 @@ class TestSimpleJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             ),
         ]
         formatter = SimpleJobsFormatter()
@@ -1510,6 +1604,8 @@ class TestTabularJobRow:
             ),
             scheduler_enabled=True,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
     def test_with_job_name(self, datetime_formatter: DatetimeFormatter) -> None:
@@ -1646,6 +1742,8 @@ class TestTabularJobsFormatter:
             ),
             scheduler_enabled=True,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
         formatter = TabularJobsFormatter(
             "owner",
@@ -1695,6 +1793,8 @@ class TestTabularJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             ),
             JobDescription(
                 status=JobStatus.PENDING,
@@ -1728,6 +1828,8 @@ class TestTabularJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             ),
         ]
         formatter = TabularJobsFormatter(
@@ -1764,6 +1866,8 @@ class TestTabularJobsFormatter:
             ),
             scheduler_enabled=True,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         columns = parse_ps_columns("{status;align=right;min=20;Status Code}")
@@ -1804,6 +1908,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=True,
                 pass_config=True,
                 life_span=life_span,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             )
             for i, life_span in enumerate(life_spans, 1)
         ]
@@ -1869,6 +1975,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=False,
                 pass_config=True,
                 internal_hostname="host.local",
+                total_price_credits="150",
+                price_credits_per_hour="15",
             )
             for i, item in enumerate(items, 1)
         ]
@@ -1911,6 +2019,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=False,
                 pass_config=True,
                 internal_hostname="host.local",
+                total_price_credits="150",
+                price_credits_per_hour="15",
             )
             for i, working_dir in enumerate(items, 1)
         ]
@@ -1951,6 +2061,8 @@ class TestTabularJobsFormatter:
                 pass_config=True,
                 internal_hostname="host.local",
                 preset_name=preset_name,
+                total_price_credits="150",
+                price_credits_per_hour="15",
             )
             for i, preset_name in enumerate(items, 1)
         ]
@@ -2012,6 +2124,8 @@ class TestLifeSpanUpdateFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         formatter = LifeSpanUpdateFormatter(
@@ -2045,6 +2159,8 @@ class TestLifeSpanUpdateFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=3600,
+            total_price_credits="150",
+            price_credits_per_hour="15",
         )
 
         formatter = LifeSpanUpdateFormatter(

--- a/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
+++ b/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
@@ -3,6 +3,7 @@ import itertools
 import sys
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Any, Callable, Optional
 
 import pytest
@@ -111,8 +112,8 @@ def job_descr_no_name() -> JobDescription:
         ),
         scheduler_enabled=True,
         pass_config=True,
-        total_price_credits="150",
-        price_credits_per_hour="15",
+        total_price_credits=Decimal("150"),
+        price_credits_per_hour=Decimal("15"),
     )
 
 
@@ -139,8 +140,8 @@ def job_descr() -> JobDescription:
         ),
         scheduler_enabled=True,
         pass_config=True,
-        total_price_credits="150",
-        price_credits_per_hour="15",
+        total_price_credits=Decimal("150"),
+        price_credits_per_hour=Decimal("15"),
     )
 
 
@@ -153,8 +154,8 @@ class TestJobStartProgress:
         name: Optional[str] = None,
         life_span: Optional[float] = None,
         description: str = "ErrorDesc",
-        total_price_credits: str = "150",
-        price_credits_per_hour: str = "15",
+        total_price_credits: Decimal = Decimal("150"),
+        price_credits_per_hour: Decimal = Decimal("15"),
     ) -> JobDescription:
         return JobDescription(
             name=name,
@@ -304,8 +305,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -344,8 +345,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -384,8 +385,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -424,8 +425,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=1.0 * ((60 * 60 * 24 * 1) + (60 * 60 * 2) + (60 * 3) + 4),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -464,8 +465,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=0.0,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -505,8 +506,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             restart_policy=JobRestartPolicy.ALWAYS,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -544,8 +545,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -580,8 +581,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -617,8 +618,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -653,8 +654,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -691,8 +692,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -750,8 +751,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -790,8 +791,8 @@ class TestJobOutputFormatter:
             pass_config=True,
             internal_hostname="host.local",
             internal_hostname_named="test-job--test-owner.local",
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -829,8 +830,8 @@ class TestJobOutputFormatter:
             scheduler_enabled=False,
             pass_config=True,
             internal_hostname="host.local",
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -876,8 +877,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -939,8 +940,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -997,8 +998,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         rich_cmp(
@@ -1069,8 +1070,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1132,8 +1133,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1179,8 +1180,8 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1216,8 +1217,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1253,8 +1254,8 @@ class TestJobOutputFormatter:
             owner="owner",
             cluster_name="default",
             uri=URL("job://default/owner/test-job"),
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1291,8 +1292,46 @@ class TestJobOutputFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
+        )
+
+        uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
+        rich_cmp(
+            JobStatusFormatter(
+                uri_formatter=uri_fmtr, datetime_formatter=datetime_formatter
+            )(description)
+        )
+
+    def test_job_with_partial_credits(
+        self, rich_cmp: Any, datetime_formatter: DatetimeFormatter
+    ) -> None:
+        description = JobDescription(
+            status=JobStatus.RUNNING,
+            owner="test-user",
+            name="test-job",
+            cluster_name="default",
+            org_name="test-job-org-name",
+            id="test-job",
+            uri=URL("job://default/test-user/test-job"),
+            history=JobStatusHistory(
+                status=JobStatus.RUNNING,
+                reason="ContainerRunning",
+                description="",
+                created_at=isoparse("2018-09-25T12:28:21.298672+00:00"),
+                started_at=isoparse("2018-09-25T12:28:24.759433+00:00"),
+                finished_at=None,
+            ),
+            http_url=URL("http://local.host.test/"),
+            container=Container(
+                command="test-command",
+                image=RemoteImage.new_external_image(name="test-image"),
+                resources=Resources(16, 0.1, 0, None, False, None, None),
+            ),
+            scheduler_enabled=False,
+            pass_config=True,
+            total_price_credits=Decimal(150 / 15000),
+            price_credits_per_hour=Decimal(15 / 15000),
         )
 
         uri_fmtr = uri_formatter(username="test-user", cluster_name="test-cluster")
@@ -1540,8 +1579,8 @@ class TestSimpleJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             ),
             JobDescription(
                 status=JobStatus.PENDING,
@@ -1564,8 +1603,8 @@ class TestSimpleJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             ),
         ]
         formatter = SimpleJobsFormatter()
@@ -1604,8 +1643,8 @@ class TestTabularJobRow:
             ),
             scheduler_enabled=True,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
     def test_with_job_name(self, datetime_formatter: DatetimeFormatter) -> None:
@@ -1742,8 +1781,8 @@ class TestTabularJobsFormatter:
             ),
             scheduler_enabled=True,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
         formatter = TabularJobsFormatter(
             "owner",
@@ -1793,8 +1832,8 @@ class TestTabularJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             ),
             JobDescription(
                 status=JobStatus.PENDING,
@@ -1828,8 +1867,8 @@ class TestTabularJobsFormatter:
                 ),
                 scheduler_enabled=True,
                 pass_config=True,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             ),
         ]
         formatter = TabularJobsFormatter(
@@ -1866,8 +1905,8 @@ class TestTabularJobsFormatter:
             ),
             scheduler_enabled=True,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         columns = parse_ps_columns("{status;align=right;min=20;Status Code}")
@@ -1908,8 +1947,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=True,
                 pass_config=True,
                 life_span=life_span,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             )
             for i, life_span in enumerate(life_spans, 1)
         ]
@@ -1975,8 +2014,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=False,
                 pass_config=True,
                 internal_hostname="host.local",
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             )
             for i, item in enumerate(items, 1)
         ]
@@ -2019,8 +2058,8 @@ class TestTabularJobsFormatter:
                 scheduler_enabled=False,
                 pass_config=True,
                 internal_hostname="host.local",
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             )
             for i, working_dir in enumerate(items, 1)
         ]
@@ -2061,8 +2100,8 @@ class TestTabularJobsFormatter:
                 pass_config=True,
                 internal_hostname="host.local",
                 preset_name=preset_name,
-                total_price_credits="150",
-                price_credits_per_hour="15",
+                total_price_credits=Decimal("150"),
+                price_credits_per_hour=Decimal("15"),
             )
             for i, preset_name in enumerate(items, 1)
         ]
@@ -2124,8 +2163,8 @@ class TestLifeSpanUpdateFormatter:
             ),
             scheduler_enabled=False,
             pass_config=True,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         formatter = LifeSpanUpdateFormatter(
@@ -2159,8 +2198,8 @@ class TestLifeSpanUpdateFormatter:
             scheduler_enabled=False,
             pass_config=True,
             life_span=3600,
-            total_price_credits="150",
-            price_credits_per_hour="15",
+            total_price_credits=Decimal("150"),
+            price_credits_per_hour=Decimal("15"),
         )
 
         formatter = LifeSpanUpdateFormatter(

--- a/neuro-cli/tests/unit/test_job.py
+++ b/neuro-cli/tests/unit/test_job.py
@@ -292,6 +292,8 @@ def test_job_to_args_simple() -> None:
         scheduler_enabled=False,
         pass_config=False,
         preset_name="testing",
+        total_price_credits="150",
+        price_credits_per_hour="15",
     )
     assert _job_to_cli_args(job) == [
         "--preset",
@@ -328,6 +330,8 @@ def test_job_to_args_drop_env_when_pass_config() -> None:
         scheduler_enabled=False,
         pass_config=True,
         preset_name="testing",
+        total_price_credits="150",
+        price_credits_per_hour="15",
     )
     assert _job_to_cli_args(job) == [
         "--preset",
@@ -411,6 +415,8 @@ def test_job_to_args_complex() -> None:
         life_span=200,
         schedule_timeout=3600 * 24 * 2 + 3600 * 11 + 60 * 17 + 12,
         privileged=True,
+        total_price_credits="150",
+        price_credits_per_hour="15",
     )
     assert _job_to_cli_args(job) == [
         "--preset",

--- a/neuro-cli/tests/unit/test_job.py
+++ b/neuro-cli/tests/unit/test_job.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Callable, Tuple
 
@@ -292,8 +293,8 @@ def test_job_to_args_simple() -> None:
         scheduler_enabled=False,
         pass_config=False,
         preset_name="testing",
-        total_price_credits="150",
-        price_credits_per_hour="15",
+        total_price_credits=Decimal("150"),
+        price_credits_per_hour=Decimal("15"),
     )
     assert _job_to_cli_args(job) == [
         "--preset",
@@ -330,8 +331,8 @@ def test_job_to_args_drop_env_when_pass_config() -> None:
         scheduler_enabled=False,
         pass_config=True,
         preset_name="testing",
-        total_price_credits="150",
-        price_credits_per_hour="15",
+        total_price_credits=Decimal("150"),
+        price_credits_per_hour=Decimal("15"),
     )
     assert _job_to_cli_args(job) == [
         "--preset",
@@ -415,8 +416,8 @@ def test_job_to_args_complex() -> None:
         life_span=200,
         schedule_timeout=3600 * 24 * 2 + 3600 * 11 + 60 * 17 + 12,
         privileged=True,
-        total_price_credits="150",
-        price_credits_per_hour="15",
+        total_price_credits=Decimal("150"),
+        price_credits_per_hour=Decimal("15"),
     )
     assert _job_to_cli_args(job) == [
         "--preset",

--- a/neuro-cli/tests/unit/test_utils.py
+++ b/neuro-cli/tests/unit/test_utils.py
@@ -55,6 +55,8 @@ def _job_entry(job_id: str, cluster_name: str = "default") -> Dict[str, Any]:
         "name": "my-job-name",
         "internal_hostname": f"job-id.{cluster_name}",
         "internal_hostname_named": f"my-job-name--job-owner.{cluster_name}",
+        "total_price_credits": "150",
+        "price_credits_per_hour": "15",
     }
 
 

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -1073,6 +1073,10 @@ def _job_to_api(
     if privileged:
         primitive["privileged"] = privileged
     if org_name:
+        log.warning(
+            "'org_name' parameter is not fully supported yet, "
+            "and will be ignored by the system!"
+        )
         primitive["org_name"] = org_name
     primitive["cluster_name"] = cluster_name
     return primitive

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -216,8 +216,8 @@ class JobDescription:
     scheduler_enabled: bool
     pass_config: bool
     uri: URL
-    total_price_credits: str
-    price_credits_per_hour: str
+    total_price_credits: Decimal
+    price_credits_per_hour: Decimal
     name: Optional[str] = None
     tags: Sequence[str] = ()
     description: Optional[str] = None

--- a/neuro-sdk/src/neuro_sdk/jobs.py
+++ b/neuro-sdk/src/neuro_sdk/jobs.py
@@ -6,6 +6,7 @@ import sys
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from decimal import Decimal
 from functools import partial
 from typing import (
     Any,
@@ -215,6 +216,8 @@ class JobDescription:
     scheduler_enabled: bool
     pass_config: bool
     uri: URL
+    total_price_credits: str
+    price_credits_per_hour: str
     name: Optional[str] = None
     tags: Sequence[str] = ()
     description: Optional[str] = None
@@ -225,6 +228,7 @@ class JobDescription:
     life_span: Optional[float] = None
     schedule_timeout: Optional[float] = None
     preset_name: Optional[str] = None
+    org_name: Optional[str] = None
     preemptible_node: bool = False
     privileged: bool = False
     _internal: JobDescriptionInternal = JobDescriptionInternal()
@@ -313,6 +317,7 @@ class Jobs(metaclass=NoPublicConstructor):
         schedule_timeout: Optional[float] = None,
         restart_policy: JobRestartPolicy = JobRestartPolicy.NEVER,
         life_span: Optional[float] = None,
+        org_name: Optional[str] = None,
     ) -> JobDescription:
         url = self._config.api_url / "jobs"
         payload = _job_to_api(
@@ -325,6 +330,7 @@ class Jobs(metaclass=NoPublicConstructor):
             schedule_timeout=schedule_timeout,
             restart_policy=restart_policy,
             life_span=life_span,
+            org_name=org_name,
         )
         payload["container"] = _container_to_api(
             config=self._config,
@@ -353,6 +359,7 @@ class Jobs(metaclass=NoPublicConstructor):
         image: RemoteImage,
         preset_name: str,
         cluster_name: Optional[str] = None,
+        org_name: Optional[str] = None,
         entrypoint: Optional[str] = None,
         command: Optional[str] = None,
         working_dir: Optional[str] = None,
@@ -402,6 +409,7 @@ class Jobs(metaclass=NoPublicConstructor):
             restart_policy=restart_policy,
             life_span=life_span,
             privileged=privileged,
+            org_name=org_name,
         )
         payload.update(**container_payload)
         auth = await self._config._api_auth()
@@ -964,6 +972,8 @@ def _job_status_item_from_api(res: Dict[str, Any]) -> JobStatusItem:
 
 
 def _job_description_from_api(res: Dict[str, Any], parse: Parser) -> JobDescription:
+    # TODO y.s.: maybe, catch KeyErrors and re-raise with an error message like
+    #   "SDK and API has incompatible versions: {key} was not found in the API responce"
     container = _container_from_api(res["container"], parse)
     owner = res["owner"]
     cluster_name = res["cluster_name"]
@@ -993,11 +1003,16 @@ def _job_description_from_api(res: Dict[str, Any], parse: Parser) -> JobDescript
     life_span = (
         max_run_time_minutes * 60.0 if max_run_time_minutes is not None else None
     )
+    # TODO: this change requires a new release of API with
+    # https://github.com/neuro-inc/platform-api/pull/1770 merged
+    total_price_credits = Decimal(res["total_price_credits"])
+    price_credits_per_hour = Decimal(res["price_credits_per_hour"])
     return JobDescription(
         status=_calc_status(res["status"]),
         id=res["id"],
         owner=owner,
         cluster_name=cluster_name,
+        org_name=res.get("org_name"),
         history=history,
         container=container,
         scheduler_enabled=res["scheduler_enabled"],
@@ -1014,6 +1029,8 @@ def _job_description_from_api(res: Dict[str, Any], parse: Parser) -> JobDescript
         life_span=life_span,
         schedule_timeout=res.get("schedule_timeout", None),
         preset_name=res.get("preset_name"),
+        total_price_credits=total_price_credits,
+        price_credits_per_hour=price_credits_per_hour,
         _internal=JobDescriptionInternal(
             materialized=res.get("materialized", False),
             being_dropped=res.get("being_dropped", False),
@@ -1034,6 +1051,7 @@ def _job_to_api(
     restart_policy: JobRestartPolicy = JobRestartPolicy.NEVER,
     life_span: Optional[float] = None,
     privileged: bool = False,
+    org_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     primitive: Dict[str, Any] = {"pass_config": pass_config}
     if name:
@@ -1054,6 +1072,8 @@ def _job_to_api(
         primitive["wait_for_jobs_quota"] = wait_for_jobs_quota
     if privileged:
         primitive["privileged"] = privileged
+    if org_name:
+        primitive["org_name"] = org_name
     primitive["cluster_name"] = cluster_name
     return primitive
 

--- a/neuro-sdk/tests/test_jobs.py
+++ b/neuro-sdk/tests/test_jobs.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import sys
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any, Callable, Dict, List, Optional
 
 import pytest
@@ -561,6 +562,8 @@ async def test_status_failed(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-id",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "submit-image-name",
             "command": "submit-command",
@@ -625,6 +628,8 @@ async def test_status_being_dropped(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-id",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "submit-image-name",
             "command": "submit-command",
@@ -687,6 +692,8 @@ async def test_status_with_http(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-id",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "submit-image-name",
             "command": "submit-command",
@@ -747,6 +754,8 @@ async def test_status_with_tpu(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-id",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "submit-image-name",
             "command": "submit-command",
@@ -807,6 +816,8 @@ async def test_job_start(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -896,6 +907,8 @@ async def test_job_start_with_privileged_flag(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -958,7 +971,10 @@ async def test_job_run(
         },
         "owner": "owner",
         "cluster_name": "default",
+        "org_name": "my-test-org",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1055,6 +1071,8 @@ async def test_job_run_with_wait_for_quota(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1131,6 +1149,8 @@ async def test_job_run_with_name_and_description(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1235,6 +1255,8 @@ async def test_job_run_with_tags(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1337,6 +1359,8 @@ async def test_job_run_no_volumes(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1417,6 +1441,8 @@ async def test_job_run_with_relative_volume_uris(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1521,6 +1547,8 @@ async def test_job_run_with_secret_uris(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1619,6 +1647,8 @@ async def test_job_run_with_disk_volume_uris(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1711,6 +1741,8 @@ async def test_job_run_preemptible(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1814,6 +1846,8 @@ async def test_job_run_schedule_timeout(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1887,6 +1921,8 @@ async def test_job_run_tpu(
         "owner": "owner",
         "cluster_name": "default",
         "uri": "job://default/owner/job-cf519ed3-9ea5-48f6-a8c5-492b810eb56f",
+        "total_price_credits": "10.01",
+        "price_credits_per_hour": "20",
         "container": {
             "image": "gcr.io/light-reality-205619/ubuntu:latest",
             "command": "date",
@@ -1992,8 +2028,11 @@ def create_job_response(
     status: str,
     owner: str = "owner",
     name: Optional[str] = None,
+    org_name: Optional[str] = None,
     image: str = "submit-image-name",
     tags: Optional[List[str]] = None,
+    total_price_credits: str = "10.01",
+    price_credits_per_hour: str = "20",
 ) -> Dict[str, Any]:
     result = {
         "id": id,
@@ -2021,11 +2060,15 @@ def create_job_response(
         "owner": owner,
         "cluster_name": "default",
         "uri": f"job://default/{owner}/{id}",
+        "total_price_credits": total_price_credits,
+        "price_credits_per_hour": price_credits_per_hour,
     }
     if name:
         result["name"] = name
     if tags:
         result["tags"] = tags
+    if org_name:
+        result["org_name"] = org_name
     return result
 
 
@@ -2688,3 +2731,113 @@ async def test_bump_life_span(
             additional_life_span=3600,  # 1h
         )
         assert called
+
+
+async def test_job_price_credits(
+    aiohttp_server: _TestServerFactory, make_client: _MakeClient
+) -> None:
+    total_price_credits = "105000.00000000000123"
+    price_credits_per_hour = "0.000123"
+
+    async def handler(request: web.Request) -> web.Response:
+        to_api_request = await request.json()
+        # we do not send total_price_credits and price_credits_per_hour
+        # they should be controled by the API
+        assert to_api_request == {
+            "container": {
+                "image": "submit-image-name",
+                "resources": {"memory_mb": 16, "cpu": 0.5, "shm": True},
+            },
+            "scheduler_enabled": False,
+            "pass_config": False,
+            "cluster_name": "default",
+        }
+        api_responce = create_job_response(
+            "job-id-1",
+            "running",
+            total_price_credits=total_price_credits,
+            price_credits_per_hour=price_credits_per_hour,
+        )
+        return web.json_response(api_responce)
+
+    app = web.Application()
+    app.router.add_post("/jobs", handler)
+
+    srv = await aiohttp_server(app)
+
+    async with make_client(srv.make_url("/")) as client:
+        container = Container(
+            image=RemoteImage.new_external_image(name="submit-image-name"),
+            resources=Resources(16, 0.5),
+        )
+        resp = await client.jobs.run(container=container)
+        assert resp.total_price_credits == Decimal(total_price_credits)
+        assert resp.price_credits_per_hour == Decimal(price_credits_per_hour)
+
+
+async def test_job_with_org_name(
+    aiohttp_server: _TestServerFactory, make_client: _MakeClient
+) -> None:
+    org_name = "my-awesome-organization"
+
+    async def handler(request: web.Request) -> web.Response:
+        to_api_request = await request.json()
+        assert to_api_request == {
+            "container": {
+                "image": "submit-image-name",
+                "resources": {"memory_mb": 16, "cpu": 0.5, "shm": True},
+            },
+            "scheduler_enabled": False,
+            "pass_config": False,
+            "cluster_name": "default",
+            "org_name": org_name,
+        }
+        api_responce = create_job_response(
+            "job-id-1",
+            "running",
+            org_name=org_name,
+        )
+        return web.json_response(api_responce)
+
+    app = web.Application()
+    app.router.add_post("/jobs", handler)
+
+    srv = await aiohttp_server(app)
+
+    async with make_client(srv.make_url("/")) as client:
+        container = Container(
+            image=RemoteImage.new_external_image(name="submit-image-name"),
+            resources=Resources(16, 0.5),
+        )
+        resp = await client.jobs.run(container=container, org_name=org_name)
+        assert resp.org_name == org_name
+
+
+async def test_job_without_org_name(
+    aiohttp_server: _TestServerFactory, make_client: _MakeClient
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        to_api_request = await request.json()
+        assert to_api_request == {
+            "container": {
+                "image": "submit-image-name",
+                "resources": {"memory_mb": 16, "cpu": 0.5, "shm": True},
+            },
+            "scheduler_enabled": False,
+            "pass_config": False,
+            "cluster_name": "default",
+        }
+        return web.json_response(create_job_response("job-id-1", "running"))
+
+    app = web.Application()
+    app.router.add_post("/jobs", handler)
+
+    srv = await aiohttp_server(app)
+
+    async with make_client(srv.make_url("/")) as client:
+        container = Container(
+            image=RemoteImage.new_external_image(name="submit-image-name"),
+            resources=Resources(16, 0.5),
+        )
+        resp = await client.jobs.run(container=container)
+        assert not resp.org_name


### PR DESCRIPTION
Closes https://github.com/neuro-inc/platform-client-python/issues/2401

Diff summary:
- SDK:
  - added optional `org_name` field to JobDescription (sending to API and parsing the response)
  - added mandatory `total_price_credits` and `price_credits_per_hour` fields sent by API
- CLI:
  - optionally ( if got from API ) show `org_name` JobStatusFormatter
  - show `Price (credits / hour) = price_credits_per_hour` in JobStatusFormatter (FR by Synthesis)
  - show `Current cost = total_price_credits` in JobStatusFormatter (FR by Synthesis)