### PR TITLE
Support orgs in bucket urls

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -2747,7 +2747,6 @@ Name | Description|
 |_--help_|Show this message and exit.|
 |_--cluster CLUSTER_|Look on a specified cluster \(the current cluster by default).|
 |_\--full-uri_|Output full disk URI.|
-|_--org ORG_|Look on a specified org \(the current org by default).|
 
 
 

--- a/neuro-cli/docs/secret.md
+++ b/neuro-cli/docs/secret.md
@@ -38,7 +38,6 @@ List secrets.
 | _--help_ | Show this message and exit. |
 | _--cluster CLUSTER_ | Look on a specified cluster \(the current cluster by default\). |
 | _--full-uri_ | Output full disk URI. |
-| _--org ORG_ | Look on a specified org \(the current org by default\). |
 
 
 

--- a/neuro-cli/src/neuro_cli/click_types.py
+++ b/neuro-cli/src/neuro_cli/click_types.py
@@ -642,7 +642,7 @@ class BlobPathURLCompleter(PathURLCompleter):
     async def _iter_dir(
         self, root: Root, uri: URL
     ) -> AsyncIterator[PathURLCompleter.DirEntry]:
-        res = root.client.parse.split_blob_uri(uri)
+        res = await root.client.parse.split_blob_uri(uri)
         async with root.client.buckets.list_blobs(uri) as it:
             async for blob_entry in it:
                 if blob_entry.key == res.key:

--- a/neuro-cli/src/neuro_cli/secrets.py
+++ b/neuro-cli/src/neuro_cli/secrets.py
@@ -26,14 +26,11 @@ def secret() -> None:
     type=CLUSTER,
     help="Look on a specified cluster (the current cluster by default).",
 )
-@option(
-    "--org",
-    type=ORG,
-    help="Look on a specified org (the current org by default).",
-)
 @option("--full-uri", is_flag=True, help="Output full disk URI.")
 async def ls(
-    root: Root, full_uri: bool, cluster: Optional[str], org: Optional[str]
+    root: Root,
+    full_uri: bool,
+    cluster: Optional[str],
 ) -> None:
     """
     List secrets.
@@ -55,7 +52,7 @@ async def ls(
 
     secrets = []
     with root.status("Fetching secrets") as status:
-        async with root.client.secrets.list(cluster_name=cluster, org_name=org) as it:
+        async with root.client.secrets.list(cluster_name=cluster) as it:
             async for secret in it:
                 secrets.append(secret)
                 status.update(f"Fetching secrets ({len(secrets)} loaded)")

--- a/neuro-cli/src/neuro_cli/share.py
+++ b/neuro-cli/src/neuro_cli/share.py
@@ -50,7 +50,7 @@ async def grant(root: Root, uri: str, user: str, permission: str) -> None:
     neuro acl grant job:///my_job_id alice write
     """
     try:
-        uri_obj = parse_resource_for_sharing(uri, root)
+        uri_obj = await parse_resource_for_sharing(uri, root)
         action_obj = parse_permission_action(permission)
         permission_obj = Permission(uri=uri_obj, action=action_obj)
         log.info(f"Using resource '{permission_obj.uri}'")
@@ -86,7 +86,7 @@ async def revoke(root: Root, uri: str, user: str) -> None:
     neuro acl revoke job:///my_job_id alice
     """
     try:
-        uri_obj = parse_resource_for_sharing(uri, root)
+        uri_obj = await parse_resource_for_sharing(uri, root)
         log.info(f"Using resource '{uri_obj}'")
 
         await root.client.users.revoke(user, uri_obj)

--- a/neuro-cli/src/neuro_cli/utils.py
+++ b/neuro-cli/src/neuro_cli/utils.py
@@ -529,7 +529,7 @@ async def resolve_bucket_credential(
 SHARE_SCHEMES = ("storage", "image", "job", "blob", "role", "secret", "disk")
 
 
-def parse_resource_for_sharing(uri: str, root: Root) -> URL:
+async def parse_resource_for_sharing(uri: str, root: Root) -> URL:
     """Parses the neuro resource URI string.
     Available schemes: storage, image, job. For image URIs, tags are not allowed.
     """
@@ -542,7 +542,7 @@ def parse_resource_for_sharing(uri: str, root: Root) -> URL:
 
     if uri_res.scheme == "blob":
         # Lets check that this is bucket url, not object in bucket
-        res = root.client.parse.split_blob_uri(uri_res)
+        res = await root.client.parse.split_blob_uri(uri_res)
         if res.key:
             raise ValueError(
                 "Only bucket level permissions are supported for Blob Storage"

--- a/neuro-cli/tests/unit/test_utils.py
+++ b/neuro-cli/tests/unit/test_utils.py
@@ -506,92 +506,92 @@ def test_parse_file_resource_with_tilde(root: Root) -> None:
         parse_file_resource(f"storage://~/resource", root)
 
 
-def test_parse_resource_for_sharing_image_no_tag(root: Root) -> None:
+async def test_parse_resource_for_sharing_image_no_tag(root: Root) -> None:
     uri = "image:ubuntu"
-    parsed = parse_resource_for_sharing(uri, root)
+    parsed = await parse_resource_for_sharing(uri, root)
     assert parsed == URL(
         f"image://{root.client.cluster_name}/{root.client.username}/ubuntu"
     )
 
 
-def test_parse_resource_for_sharing_image_non_ascii(root: Root) -> None:
+async def test_parse_resource_for_sharing_image_non_ascii(root: Root) -> None:
     uri = "image:образ"
-    parsed = parse_resource_for_sharing(uri, root)
+    parsed = await parse_resource_for_sharing(uri, root)
     assert parsed == URL(
         f"image://{root.client.cluster_name}/{root.client.username}/образ"
     )
     assert parsed.path == f"/{root.client.username}/образ"
 
 
-def test_parse_resource_for_sharing_image_percent_encoded(root: Root) -> None:
+async def test_parse_resource_for_sharing_image_percent_encoded(root: Root) -> None:
     uri = "image:%252d%3f%23"
-    parsed = parse_resource_for_sharing(uri, root)
+    parsed = await parse_resource_for_sharing(uri, root)
     assert parsed == URL(
         f"image://{root.client.cluster_name}/{root.client.username}/%252d%3f%23"
     )
     assert parsed.path == f"/{root.client.username}/%2d?#"
 
 
-def test_parse_resource_for_sharing_image_with_tag_fail(root: Root) -> None:
+async def test_parse_resource_for_sharing_image_with_tag_fail(root: Root) -> None:
     uri = "image:ubuntu:latest"
     with pytest.raises(ValueError, match="tag is not allowed"):
-        parse_resource_for_sharing(uri, root)
+        await parse_resource_for_sharing(uri, root)
 
 
-def test_parse_resource_for_sharing_all_user_images(root: Root) -> None:
+async def test_parse_resource_for_sharing_all_user_images(root: Root) -> None:
     uri = "image:/otheruser"
-    parsed = parse_resource_for_sharing(uri, root)
+    parsed = await parse_resource_for_sharing(uri, root)
     assert parsed == URL(f"image://{root.client.cluster_name}/otheruser")
 
 
-def _test_parse_resource_for_sharing_all_cluster_images(root: Root) -> None:
+async def _test_parse_resource_for_sharing_all_cluster_images(root: Root) -> None:
     uri = "image://"
-    parsed = parse_resource_for_sharing(uri, root)
+    parsed = await parse_resource_for_sharing(uri, root)
     assert parsed == URL(f"image://{root.client.cluster_name}/otheruser")
 
 
-def test_parse_resource_for_sharing_no_scheme(root: Root) -> None:
+async def test_parse_resource_for_sharing_no_scheme(root: Root) -> None:
     with pytest.raises(ValueError, match=r"URI Scheme not specified"):
-        parse_resource_for_sharing("scheme-less/resource", root)
+        await parse_resource_for_sharing("scheme-less/resource", root)
 
 
-def test_parse_resource_for_sharing_unsupported_scheme(root: Root) -> None:
+async def test_parse_resource_for_sharing_unsupported_scheme(root: Root) -> None:
     with pytest.raises(ValueError, match=r"Invalid scheme"):
-        parse_resource_for_sharing("http://neu.ro", root)
+        await parse_resource_for_sharing("http://neu.ro", root)
     with pytest.raises(ValueError, match=r"Invalid scheme"):
-        parse_resource_for_sharing("file:///etc/password", root)
+        await parse_resource_for_sharing("file:///etc/password", root)
     with pytest.raises(ValueError, match=r"Invalid scheme"):
-        parse_resource_for_sharing(r"c:scheme-less/resource", root)
+        await parse_resource_for_sharing(r"c:scheme-less/resource", root)
 
 
-def test_parse_resource_for_sharing_user_less(root: Root) -> None:
-    user_less_permission = parse_resource_for_sharing("storage:resource", root)
+async def test_parse_resource_for_sharing_user_less(root: Root) -> None:
+    user_less_permission = await parse_resource_for_sharing("storage:resource", root)
     assert user_less_permission == URL(
         f"storage://{root.client.cluster_name}/{root.client.username}/resource"
     )
 
 
-def test_parse_resource_for_sharing_with_user(root: Root) -> None:
-    full_permission = parse_resource_for_sharing(
+async def test_parse_resource_for_sharing_with_user(root: Root) -> None:
+    full_permission = await parse_resource_for_sharing(
         f"storage://{root.client.cluster_name}/{root.client.username}/resource", root
     )
     assert full_permission == URL(
         f"storage://{root.client.cluster_name}/{root.client.username}/resource"
     )
-    full_permission = parse_resource_for_sharing(
+    full_permission = await parse_resource_for_sharing(
         f"storage://default/alice/resource", root
     )
     assert full_permission == URL(f"storage://default/alice/resource")
 
 
-def test_parse_resource_for_sharing_with_tilde(root: Root) -> None:
+async def test_parse_resource_for_sharing_with_tilde(root: Root) -> None:
     with pytest.raises(ValueError, match=r"Cannot expand user for "):
-        parse_resource_for_sharing(f"storage://~/resource", root)
+        await parse_resource_for_sharing(f"storage://~/resource", root)
 
 
-def test_parse_resource_for_sharing_with_tilde_relative(root: Root) -> None:
+async def test_parse_resource_for_sharing_with_tilde_relative(root: Root) -> None:
     with pytest.raises(ValueError, match=r"Cannot expand user for "):
-        parse_resource_for_sharing(f"storage:~/resource", root)
+        await parse_resource_for_sharing(f"storage:~/resource", root)
 
 
 def test_parse_permission_action_read_lowercase() -> None:

--- a/neuro-sdk/src/neuro_sdk/_buckets.py
+++ b/neuro-sdk/src/neuro_sdk/_buckets.py
@@ -445,7 +445,7 @@ class Buckets(metaclass=NoPublicConstructor):
         recursive: bool = False,
         limit: Optional[int] = None,
     ) -> AsyncIterator[BucketEntry]:
-        res = self._parser.split_blob_uri(uri)
+        res = await self._parser.split_blob_uri(uri)
         async with self._get_provider(
             res.bucket_name, res.cluster_name, res.owner
         ) as provider:
@@ -457,7 +457,7 @@ class Buckets(metaclass=NoPublicConstructor):
 
     @asyncgeneratorcontextmanager
     async def glob_blobs(self, uri: URL) -> AsyncIterator[BucketEntry]:
-        res = self._parser.split_blob_uri(uri)
+        res = await self._parser.split_blob_uri(uri)
         if _has_magic(res.bucket_name):
             raise ValueError(
                 "You can not glob on bucket names. Please provide name explicitly."
@@ -535,7 +535,7 @@ class Buckets(metaclass=NoPublicConstructor):
         progress: Optional[AbstractFileProgress] = None,
     ) -> None:
         src = normalize_local_path_uri(src)
-        res = self._parser.split_blob_uri(dst)
+        res = await self._parser.split_blob_uri(dst)
         async with self._get_bucket_fs(
             res.bucket_name, res.cluster_name, res.owner
         ) as bucket_fs:
@@ -556,7 +556,7 @@ class Buckets(metaclass=NoPublicConstructor):
         continue_: bool = False,
         progress: Optional[AbstractFileProgress] = None,
     ) -> None:
-        res = self._parser.split_blob_uri(src)
+        res = await self._parser.split_blob_uri(src)
         dst = normalize_local_path_uri(dst)
         async with self._get_bucket_fs(
             res.bucket_name, res.cluster_name, res.owner
@@ -581,7 +581,7 @@ class Buckets(metaclass=NoPublicConstructor):
         progress: Optional[AbstractRecursiveFileProgress] = None,
     ) -> None:
         src = normalize_local_path_uri(src)
-        res = self._parser.split_blob_uri(dst)
+        res = await self._parser.split_blob_uri(dst)
         async with self._get_bucket_fs(
             res.bucket_name, res.cluster_name, res.owner
         ) as bucket_fs:
@@ -605,7 +605,7 @@ class Buckets(metaclass=NoPublicConstructor):
         filter: Optional[AsyncFilterFunc] = None,
         progress: Optional[AbstractRecursiveFileProgress] = None,
     ) -> None:
-        res = self._parser.split_blob_uri(src)
+        res = await self._parser.split_blob_uri(src)
         dst = normalize_local_path_uri(dst)
         async with self._get_bucket_fs(
             res.bucket_name, res.cluster_name, res.owner
@@ -621,7 +621,7 @@ class Buckets(metaclass=NoPublicConstructor):
             )
 
     async def blob_is_dir(self, uri: URL) -> bool:
-        res = self._parser.split_blob_uri(uri)
+        res = await self._parser.split_blob_uri(uri)
         if res.key.endswith("/"):
             return True
         async with self._get_bucket_fs(
@@ -636,7 +636,7 @@ class Buckets(metaclass=NoPublicConstructor):
         recursive: bool = False,
         progress: Optional[AbstractDeleteProgress] = None,
     ) -> None:
-        res = self._parser.split_blob_uri(uri)
+        res = await self._parser.split_blob_uri(uri)
         async with self._get_bucket_fs(
             res.bucket_name, res.cluster_name, res.owner
         ) as bucket_fs:
@@ -647,7 +647,7 @@ class Buckets(metaclass=NoPublicConstructor):
         uri: URL,
         expires_in_seconds: int = 3600,
     ) -> URL:
-        res = self._parser.split_blob_uri(uri)
+        res = await self._parser.split_blob_uri(uri)
         url = (
             self._get_buckets_url(res.cluster_name) / res.bucket_name / "sign_blob_url"
         )

--- a/neuro-sdk/src/neuro_sdk/_client.py
+++ b/neuro-sdk/src/neuro_sdk/_client.py
@@ -61,6 +61,7 @@ class Client(metaclass=NoPublicConstructor):
         self._version_checker: VersionChecker = VersionChecker._create(
             self._core, self._config, plugin_manager
         )
+        self._parser._set_buckets(self._buckets)
 
     async def close(self) -> None:
         if self._closed:


### PR DESCRIPTION
Unfortunately, it's impossible to parse url like `blob://cluster/part1/part2/part3/part4`. I can be any of the following:
- `part1` is username, `part2` is bucket name, `part3/part4` is path to blob.
- `part1/part2` is username with slash, `part3` is bucket name, `part4` is path to blob.
- `part1` is org, `part2` is username, `part3` is bucket name,  `part4` is path to blob.
(and some even more options). 
So I have to fetch all buckets in clusters to properly parse url.