### PR TITLE
Replace --http option with --http-port

### DIFF
--- a/CHANGELOG.D/2501.removal
+++ b/CHANGELOG.D/2501.removal
@@ -1,0 +1,1 @@
+Replace `--http` option with `--http-port`, keep `--http` option as a hidden deprecated alternative, scheduled for removal later.

--- a/CLI.md
+++ b/CLI.md
@@ -2383,8 +2383,8 @@ Name | Description|
 |_\-e, --env VAR=VAL_|Set environment variable in container. Use multiple options to define more than one variable. See `neuro help secrets` for information about passing secrets as environment variables.|
 |_\--env-file PATH_|File with environment variables to pass|
 |_\-x, --extshm / -X, --no-extshm_|Request extended '/dev/shm' space  \[default: x]|
-|_--http PORT_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--http-auth / --no-http-auth_|Enable HTTP authentication for forwarded HTTP port  \[default: True]|
+|_\--http-port PORT_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--life-span TIMEDELTA_|Optional job run-time limit in the format '1d2h3m4s' \(some parts may be missing). Set '0' to disable. Default value '1d' can be changed in the user config.|
 |_\-n, --name NAME_|Optional job name|
 |_--org ORG_|Run job in a specified org|
@@ -3575,8 +3575,8 @@ Name | Description|
 |_\-e, --env VAR=VAL_|Set environment variable in container. Use multiple options to define more than one variable. See `neuro help secrets` for information about passing secrets as environment variables.|
 |_\--env-file PATH_|File with environment variables to pass|
 |_\-x, --extshm / -X, --no-extshm_|Request extended '/dev/shm' space  \[default: x]|
-|_--http PORT_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--http-auth / --no-http-auth_|Enable HTTP authentication for forwarded HTTP port  \[default: True]|
+|_\--http-port PORT_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--life-span TIMEDELTA_|Optional job run-time limit in the format '1d2h3m4s' \(some parts may be missing). Set '0' to disable. Default value '1d' can be changed in the user config.|
 |_\-n, --name NAME_|Optional job name|
 |_--org ORG_|Run job in a specified org|

--- a/neuro-cli/docs/job.md
+++ b/neuro-cli/docs/job.md
@@ -336,8 +336,8 @@ $ neuro run -s cpu-small --entrypoint=/script.sh image:my-ubuntu:latest -- arg1 
 | _-e, --env VAR=VAL_ | Set environment variable in container. Use multiple options to define more than one variable. See `neuro help secrets` for information about passing secrets as environment variables. |
 | _--env-file PATH_ | File with environment variables to pass |
 | _-x, --extshm / -X, --no-extshm_ | Request extended '/dev/shm' space  _\[default: x\]_ |
-| _--http PORT_ | Enable HTTP port forwarding to container  _\[default: 80\]_ |
 | _--http-auth / --no-http-auth_ | Enable HTTP authentication for forwarded HTTP port  _\[default: True\]_ |
+| _--http-port PORT_ | Enable HTTP port forwarding to container  _\[default: 80\]_ |
 | _--life-span TIMEDELTA_ | Optional job run-time limit in the format '1d2h3m4s' \(some parts may be missing\). Set '0' to disable. Default value '1d' can be changed in the user config. |
 | _-n, --name NAME_ | Optional job name |
 | _--org ORG_ | Run job in a specified org |

--- a/neuro-cli/docs/shortcuts.md
+++ b/neuro-cli/docs/shortcuts.md
@@ -621,8 +621,8 @@ $ neuro run -s cpu-small --entrypoint=/script.sh image:my-ubuntu:latest -- arg1 
 | _-e, --env VAR=VAL_ | Set environment variable in container. Use multiple options to define more than one variable. See `neuro help secrets` for information about passing secrets as environment variables. |
 | _--env-file PATH_ | File with environment variables to pass |
 | _-x, --extshm / -X, --no-extshm_ | Request extended '/dev/shm' space  _\[default: x\]_ |
-| _--http PORT_ | Enable HTTP port forwarding to container  _\[default: 80\]_ |
 | _--http-auth / --no-http-auth_ | Enable HTTP authentication for forwarded HTTP port  _\[default: True\]_ |
+| _--http-port PORT_ | Enable HTTP port forwarding to container  _\[default: 80\]_ |
 | _--life-span TIMEDELTA_ | Optional job run-time limit in the format '1d2h3m4s' \(some parts may be missing\). Set '0' to disable. Default value '1d' can be changed in the user config. |
 | _-n, --name NAME_ | Optional job name |
 | _--org ORG_ | Run job in a specified org |

--- a/neuro-cli/src/neuro_cli/job.py
+++ b/neuro-cli/src/neuro_cli/job.py
@@ -1077,8 +1077,9 @@ async def run(
     neuro run -s cpu-small --entrypoint=/script.sh image:my-ubuntu:latest -- arg1 arg2
     """
     if http is not None:
+        root.console.print("[red]--http option is deprecated,", markup=True)
         root.console.print(
-            "[red]Please use  --http-port option instead of --http[/red]"
+            "[red]Please use  --http-port option instead of --http", markup=True
         )
         http_port = http
     cmd = _fix_cmd("neuro run", "IMAGE -- CMD...", cmd)

--- a/neuro-cli/tests/e2e/conftest.py
+++ b/neuro-cli/tests/e2e/conftest.py
@@ -906,7 +906,7 @@ def secret_job(helper: Helper) -> Callable[[bool, bool, Optional[str]], Dict[str
         )
         args: List[str] = []
         if http_port:
-            args += ["--http", "80"]
+            args += ["--http-port", "80"]
             if http_auth:
                 args += ["--http-auth"]
             else:

--- a/neuro-cli/tests/e2e/test_e2e_jobs.py
+++ b/neuro-cli/tests/e2e/test_e2e_jobs.py
@@ -77,7 +77,7 @@ def test_job_run(helper: Helper) -> None:
         [
             "job",
             "run",
-            "--http",
+            "--http-port",
             "80",
             "--no-wait-start",
             "--restart",
@@ -159,7 +159,7 @@ def test_job_description(helper: Helper) -> None:
         [
             "job",
             "run",
-            "--http",
+            "--http-port",
             "80",
             "--description",
             description,
@@ -827,10 +827,10 @@ def test_pass_config(helper: Helper) -> None:
 def test_job_submit_bad_http_auth(helper: Helper, http_auth: str) -> None:
     with pytest.raises(subprocess.CalledProcessError) as cm:
         helper.run_cli(
-            ["job", "run", "--http=0", http_auth, UBUNTU_IMAGE_NAME, "--", "true"]
+            ["job", "run", "--http-port=0", http_auth, UBUNTU_IMAGE_NAME, "--", "true"]
         )
     assert cm.value.returncode == 2
-    assert f"{http_auth} requires --http" in cm.value.stderr
+    assert f"{http_auth} requires --http-port" in cm.value.stderr
 
 
 @pytest.fixture
@@ -895,7 +895,7 @@ def test_job_submit_no_detach_failure(helper: Helper) -> None:
                 "-v",
                 "job",
                 "run",
-                "--http",
+                "--http-port",
                 "80",
                 UBUNTU_IMAGE_NAME,
                 "--",


### PR DESCRIPTION
Keep `--http` option as a hidden deprecated alternative, scheduled for removal later.
