### PR TITLE
Support 'neuro -q ls' and 'neuro -q blob ls' for quiet output

### DIFF
--- a/CHANGELOG.D/2506.feature
+++ b/CHANGELOG.D/2506.feature
@@ -1,0 +1,1 @@
+Support `neuro -q ls` and `neuro -q blob ls` for quiet output enforcing.

--- a/neuro-cli/src/neuro_cli/blob_storage.py
+++ b/neuro-cli/src/neuro_cli/blob_storage.py
@@ -553,7 +553,10 @@ async def ls(
     else:
         # Similar to `ls -1`, default for non-terminal on UNIX. We show full uris of
         # blobs, thus column formatting does not work too well.
-        formatter = SimpleBlobFormatter(root.color, uri_fmtr)
+        if root.tty and not root.quiet:
+            formatter = SimpleBlobFormatter(root.color, uri_fmtr)
+        else:
+            formatter = SimpleBlobFormatter(False, uri_fmtr)
 
     if not paths:
         # List Buckets instead of blobs in bucket

--- a/neuro-cli/src/neuro_cli/storage.py
+++ b/neuro-cli/src/neuro_cli/storage.py
@@ -183,12 +183,12 @@ async def ls(
                     human_readable=human_readable, color=root.color
                 )
             else:
-                if root.tty:
+                if root.tty and not root.quiet:
                     formatter = VerticalColumnsFilesFormatter(
                         width=root.terminal_size[0], color=root.color
                     )
                 else:
-                    formatter = SimpleFilesFormatter(root.color)
+                    formatter = SimpleFilesFormatter(False)
 
             if not show_all:
                 files = [item for item in files if not item.name.startswith(".")]


### PR DESCRIPTION
Fixes #2392 